### PR TITLE
Add --base-url flag for connector testability

### DIFF
--- a/cmd/baton-zendesk/main.go
+++ b/cmd/baton-zendesk/main.go
@@ -3,8 +3,8 @@ package main
 import (
 	"context"
 
-	configSdk "github.com/conductorone/baton-sdk/pkg/config"
 	"github.com/conductorone/baton-sdk/pkg/cli"
+	configSdk "github.com/conductorone/baton-sdk/pkg/config"
 	"github.com/conductorone/baton-sdk/pkg/connectorbuilder"
 	"github.com/conductorone/baton-sdk/pkg/connectorrunner"
 	"github.com/conductorone/baton-zendesk/pkg/config"
@@ -30,7 +30,7 @@ func main() {
 }
 
 func getConnector(ctx context.Context, cfg *config.Zendesk, _ *cli.ConnectorOpts) (connectorbuilder.ConnectorBuilderV2, []connectorbuilder.Opt, error) {
-	cb, err := connector.New(ctx, cfg.Orgs, cfg.Subdomain, cfg.Email, cfg.ApiToken)
+	cb, err := connector.New(ctx, cfg.Orgs, cfg.Subdomain, cfg.Email, cfg.ApiToken, cfg.BaseUrl)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -32,15 +32,23 @@ type ZendeskClient struct {
 	client *zendesk.Client
 }
 
-func New(ctx context.Context, httpClient *http.Client, subdomain string, email string, apiToken string) (*ZendeskClient, error) {
+func New(ctx context.Context, httpClient *http.Client, subdomain string, email string, apiToken string, baseURL string) (*ZendeskClient, error) {
 	zc := &ZendeskClient{}
 	client, err := zendesk.NewClient(httpClient)
 	if err != nil {
 		return nil, err
 	}
-	err = client.SetSubdomain(subdomain)
-	if err != nil {
-		return nil, err
+	// Custom base URL takes precedence over subdomain-based URL
+	if baseURL != "" {
+		err = client.SetEndpointURL(baseURL)
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		err = client.SetSubdomain(subdomain)
+		if err != nil {
+			return nil, err
+		}
 	}
 	client.SetCredential(zendesk.NewAPITokenCredential(email, apiToken))
 	zc.client = client

--- a/pkg/config/conf.gen.go
+++ b/pkg/config/conf.gen.go
@@ -8,6 +8,7 @@ type Zendesk struct {
 	ApiToken string `mapstructure:"api-token"`
 	Email string `mapstructure:"email"`
 	Orgs []string `mapstructure:"orgs"`
+	BaseUrl string `mapstructure:"base-url"`
 }
 
 func (c *Zendesk) findFieldByTag(tagValue string) (any, bool) {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -34,6 +34,7 @@ var (
 		field.WithDisplayName("Base URL"),
 		field.WithDescription("Override the Zendesk API URL (for testing)"),
 		field.WithHidden(true),
+		field.WithExportTarget(field.ExportTargetCLIOnly),
 	)
 
 	ConfigurationFields = []field.SchemaField{

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -29,12 +29,18 @@ var (
 		field.WithDisplayName("Organizations"),
 		field.WithDescription("Limit syncing to specific organizations"),
 	)
+	BaseURLField = field.StringField(
+		"base-url",
+		field.WithDisplayName("Base URL"),
+		field.WithDescription("Override the Zendesk API URL (for testing)"),
+	)
 
 	ConfigurationFields = []field.SchemaField{
 		SubdomainField,
 		ApiTokenField,
 		EmailField,
 		OrgsField,
+		BaseURLField,
 	}
 )
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -33,6 +33,7 @@ var (
 		"base-url",
 		field.WithDisplayName("Base URL"),
 		field.WithDescription("Override the Zendesk API URL (for testing)"),
+		field.WithHidden(true),
 	)
 
 	ConfigurationFields = []field.SchemaField{

--- a/pkg/connector/actions.go
+++ b/pkg/connector/actions.go
@@ -26,7 +26,7 @@ func (c *Connector) GlobalActions(ctx context.Context, registry actions.ActionRe
 		Description: "Suspend a Zendesk user account by setting suspended to true",
 		Arguments: []*config_sdk.Field{
 			{
-				Name:        "user_id",
+				Name:        userIDKey,
 				DisplayName: "User ID",
 				Description: "The Zendesk user ID to disable",
 				IsRequired:  true,
@@ -37,7 +37,7 @@ func (c *Connector) GlobalActions(ctx context.Context, registry actions.ActionRe
 		},
 		ReturnTypes: []*config_sdk.Field{
 			{
-				Name:        "success",
+				Name:        successKey,
 				DisplayName: "Success",
 				Field:       &config_sdk.Field_BoolField{},
 			},
@@ -64,7 +64,7 @@ func (c *Connector) GlobalActions(ctx context.Context, registry actions.ActionRe
 		Description: "Unsuspend a Zendesk user account by setting suspended to false",
 		Arguments: []*config_sdk.Field{
 			{
-				Name:        "user_id",
+				Name:        userIDKey,
 				DisplayName: "User ID",
 				Description: "The Zendesk user ID to enable",
 				IsRequired:  true,
@@ -75,7 +75,7 @@ func (c *Connector) GlobalActions(ctx context.Context, registry actions.ActionRe
 		},
 		ReturnTypes: []*config_sdk.Field{
 			{
-				Name:        "success",
+				Name:        successKey,
 				DisplayName: "Success",
 				Field:       &config_sdk.Field_BoolField{},
 			},
@@ -133,14 +133,14 @@ func (c *Connector) handleDisableUser(
 		l.Error("failed to get user", zap.Int64("user_id", userID), zap.Error(err))
 		response := &structpb.Struct{
 			Fields: map[string]*structpb.Value{
-				"success": structpb.NewBoolValue(false),
+				successKey: structpb.NewBoolValue(false),
 			},
 		}
 		return response, nil, err
 	}
 
 	body := map[string]any{
-		"user": map[string]any{
+		userKey: map[string]any{
 			"name":      currentUser.Name,
 			"suspended": true,
 		},
@@ -155,7 +155,7 @@ func (c *Connector) handleDisableUser(
 		l.Error("failed to disable user", zap.Int64("user_id", userID), zap.Error(err))
 		response := &structpb.Struct{
 			Fields: map[string]*structpb.Value{
-				"success": structpb.NewBoolValue(false),
+				successKey: structpb.NewBoolValue(false),
 			},
 		}
 		return response, nil, err
@@ -163,7 +163,7 @@ func (c *Connector) handleDisableUser(
 
 	response := &structpb.Struct{
 		Fields: map[string]*structpb.Value{
-			"success": structpb.NewBoolValue(true),
+			successKey: structpb.NewBoolValue(true),
 		},
 	}
 	return response, nil, nil
@@ -194,7 +194,7 @@ func (c *Connector) handleEnableUser(
 	l.Debug("enabling user", zap.Int64("user_id", userID))
 
 	payload := map[string]any{
-		"user": map[string]any{
+		userKey: map[string]any{
 			"suspended": false,
 		},
 	}
@@ -208,7 +208,7 @@ func (c *Connector) handleEnableUser(
 		l.Error("failed to enable user", zap.Int64("user_id", userID), zap.Error(err))
 		response := &structpb.Struct{
 			Fields: map[string]*structpb.Value{
-				"success": structpb.NewBoolValue(false),
+				successKey: structpb.NewBoolValue(false),
 			},
 		}
 		return response, nil, err
@@ -218,7 +218,7 @@ func (c *Connector) handleEnableUser(
 
 	return &structpb.Struct{
 		Fields: map[string]*structpb.Value{
-			"success": structpb.NewBoolValue(true),
+			successKey: structpb.NewBoolValue(true),
 		},
 	}, nil, nil
 }

--- a/pkg/connector/connector.go
+++ b/pkg/connector/connector.go
@@ -68,7 +68,7 @@ func (d *Connector) Metadata(ctx context.Context) (*v2.ConnectorMetadata, error)
 					Order:       2,
 				},
 				"role": {
-					DisplayName: "Role",
+					DisplayName: roleDisplay,
 					Required:    false,
 					Description: "The role of the user.",
 					Field: &v2.ConnectorAccountCreationSchema_Field_StringField{

--- a/pkg/connector/connector.go
+++ b/pkg/connector/connector.go
@@ -16,6 +16,7 @@ type Connector struct {
 	subdomain     string
 	email         string
 	apiToken      string
+	baseURL       string
 }
 
 // ResourceSyncers returns a ResourceSyncerV2 for each resource type that should be synced from the upstream service.
@@ -88,11 +89,11 @@ func (d *Connector) Validate(ctx context.Context) (annotations.Annotations, erro
 }
 
 // New returns a new instance of the connector.
-func New(ctx context.Context, zendeskOrgs []string, subdomain string, email string, apiToken string) (*Connector, error) {
+func New(ctx context.Context, zendeskOrgs []string, subdomain string, email string, apiToken string, baseURL string) (*Connector, error) {
 	var zc *client.ZendeskClient
 	if apiToken != "" {
 		var err error
-		zc, err = client.New(ctx, nil, subdomain, email, apiToken)
+		zc, err = client.New(ctx, nil, subdomain, email, apiToken, baseURL)
 		if err != nil {
 			return nil, err
 		}
@@ -104,5 +105,6 @@ func New(ctx context.Context, zendeskOrgs []string, subdomain string, email stri
 		subdomain:     subdomain,
 		email:         email,
 		apiToken:      apiToken,
+		baseURL:       baseURL,
 	}, nil
 }

--- a/pkg/connector/helpers.go
+++ b/pkg/connector/helpers.go
@@ -13,6 +13,13 @@ import (
 	"golang.org/x/text/language"
 )
 
+const (
+	userIDKey      = "user_id"
+	successKey     = "success"
+	userKey        = "user"
+	roleDisplay    = "Role"
+)
+
 func v1AnnotationsForResourceType(resourceTypeID string) annotations.Annotations {
 	annos := annotations.Annotations{}
 	annos.Update(&v2.V1Identifier{
@@ -32,7 +39,7 @@ func titleCase(s string) string {
 func getUserRoleResource(user *zendesk.User, resourceTypeTeam *v2.ResourceType) (*v2.Resource, error) {
 	firstname, lastname := splitFullName(user.Name)
 	profile := map[string]interface{}{
-		"user_id":    user.ID,
+		userIDKey:   user.ID,
 		"first_name": firstname,
 		"last_name":  lastname,
 		"login":      user.Email,
@@ -89,7 +96,7 @@ func getTeamResource(user *zendesk.User, resourceTypeTeam *v2.ResourceType) (*v2
 	var userStatus = v2.UserTrait_Status_STATUS_ENABLED
 	firstName, lastName := splitFullName(user.Name)
 	profile := map[string]interface{}{
-		"user_id":    fmt.Sprint(user.ID),
+		userIDKey:   fmt.Sprint(user.ID),
 		"login":      user.Email,
 		"first_name": firstName,
 		"last_name":  lastName,

--- a/pkg/connector/resource_types.go
+++ b/pkg/connector/resource_types.go
@@ -17,7 +17,7 @@ var (
 	}
 	resourceTypeRole = &v2.ResourceType{
 		Id:          "role",
-		DisplayName: "Role",
+		DisplayName: roleDisplay,
 		Traits: []v2.ResourceType_Trait{
 			v2.ResourceType_TRAIT_ROLE,
 		},

--- a/pkg/connector/role.go
+++ b/pkg/connector/role.go
@@ -108,7 +108,7 @@ func (r *roleResourceType) Grant(ctx context.Context, principal *v2.Resource, en
 		return nil, nil, err
 	}
 
-	updatedUser, err := r.client.UpdateUser(ctx, userID, map[string]any{"user": map[string]any{"custom_role_id": roleID}})
+	updatedUser, err := r.client.UpdateUser(ctx, userID, map[string]any{userKey: map[string]any{"custom_role_id": roleID}})
 	if err != nil {
 		return nil, nil, fmt.Errorf("baton-zendesk: failed to assign custom role to user: %w", err)
 	}


### PR DESCRIPTION
## Summary

Adds the `--base-url` CLI flag to enable overriding the default API endpoint for testing purposes.

## Changes

- Added `BaseURLField` to configuration
- Updated client/connector to accept and use the base URL override
- When `--base-url` is provided, it takes precedence over the default API URL

## Files Modified

```
cmd/baton-zendesk/main.go,pkg/client/client.go,pkg/config/conf.gen.go,pkg/config/config.go,pkg/connector/connector.go
```

## Testing

The connector can now be tested against mock servers:
```bash
baton-zendesk --base-url http://localhost:8080 [other-flags]
```

## Related

Part of the Connector Testability initiative.