### PR TITLE
[CXH-1279] Containerize connector: session store cache, SDK v2 interfaces, role grant fix

### DIFF
--- a/cmd/baton-zendesk/main.go
+++ b/cmd/baton-zendesk/main.go
@@ -7,6 +7,7 @@ import (
 
 	configSdk "github.com/conductorone/baton-sdk/pkg/config"
 	"github.com/conductorone/baton-sdk/pkg/connectorbuilder"
+	"github.com/conductorone/baton-sdk/pkg/connectorrunner"
 	"github.com/conductorone/baton-sdk/pkg/types"
 	"github.com/conductorone/baton-zendesk/pkg/config"
 	"github.com/grpc-ecosystem/go-grpc-middleware/logging/zap/ctxzap"
@@ -28,6 +29,8 @@ func main() {
 		connectorName,
 		getConnector,
 		config.Config,
+		connectorrunner.WithDefaultCapabilitiesConnectorBuilderV2(&connector.Connector{}),
+		connectorrunner.WithSessionStoreEnabled(),
 	)
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err.Error())

--- a/cmd/baton-zendesk/main.go
+++ b/cmd/baton-zendesk/main.go
@@ -2,17 +2,12 @@ package main
 
 import (
 	"context"
-	"fmt"
-	"os"
 
 	configSdk "github.com/conductorone/baton-sdk/pkg/config"
+	"github.com/conductorone/baton-sdk/pkg/cli"
 	"github.com/conductorone/baton-sdk/pkg/connectorbuilder"
 	"github.com/conductorone/baton-sdk/pkg/connectorrunner"
-	"github.com/conductorone/baton-sdk/pkg/types"
 	"github.com/conductorone/baton-zendesk/pkg/config"
-	"github.com/grpc-ecosystem/go-grpc-middleware/logging/zap/ctxzap"
-	"go.uber.org/zap"
-
 	"github.com/conductorone/baton-zendesk/pkg/connector"
 )
 
@@ -23,49 +18,21 @@ var (
 
 func main() {
 	ctx := context.Background()
-
-	_, cmd, err := configSdk.DefineConfiguration(
+	configSdk.RunConnector(
 		ctx,
 		connectorName,
-		getConnector,
+		version,
 		config.Config,
+		getConnector,
 		connectorrunner.WithDefaultCapabilitiesConnectorBuilderV2(&connector.Connector{}),
 		connectorrunner.WithSessionStoreEnabled(),
 	)
-	if err != nil {
-		fmt.Fprintln(os.Stderr, err.Error())
-		os.Exit(1)
-	}
-
-	cmd.Version = version
-
-	err = cmd.Execute()
-	if err != nil {
-		fmt.Fprintln(os.Stderr, err.Error())
-		os.Exit(1)
-	}
 }
 
-func getConnector(ctx context.Context, cfg *config.Zendesk) (types.ConnectorServer, error) {
-	logger := ctxzap.Extract(ctx)
-
-	cb, err := connector.New(
-		ctx,
-		cfg.Orgs,
-		cfg.Subdomain,
-		cfg.Email,
-		cfg.ApiToken,
-	)
+func getConnector(ctx context.Context, cfg *config.Zendesk, _ *cli.ConnectorOpts) (connectorbuilder.ConnectorBuilderV2, []connectorbuilder.Opt, error) {
+	cb, err := connector.New(ctx, cfg.Orgs, cfg.Subdomain, cfg.Email, cfg.ApiToken)
 	if err != nil {
-		logger.Error("error creating connector", zap.Error(err))
-		return nil, err
+		return nil, nil, err
 	}
-
-	c, err := connectorbuilder.NewConnector(ctx, cb)
-	if err != nil {
-		logger.Error("error creating connector", zap.Error(err))
-		return nil, err
-	}
-
-	return c, nil
+	return cb, nil, nil
 }

--- a/docs/connector.mdx
+++ b/docs/connector.mdx
@@ -57,22 +57,30 @@ Make a note of your subdomain.
 
 <Steps>
 <Step>
-Click **Go to Admin Center**.
+Log in to your Zendesk account at `yoursubdomain.zendesk.com`, then click the gear icon (⚙️) in the left sidebar and click **Go to Admin Center**.
 </Step>
 <Step>
-Open **Apps and integrations** in the navigation bar and click **Zendesk API**.
+Navigate to **Apps and integrations** → **APIs** → **API configuration**.
 </Step>
 <Step>
-Click the toggle to enable token access.
+Make sure both **Token Access** and **Password Access** are toggled on.
+
+<Note>
+Password Access is required to list group memberships. Without it, the connector will return authentication errors when syncing groups.
+</Note>
 </Step>
 <Step>
-Click **Add API token**, then copy and save the newly created token. 
+Navigate to **Apps and integrations** → **APIs** → **API tokens** and click **Add API token**.
+</Step>
+<Step>
+Optionally add a description, then copy the token immediately — it won't be shown again.
 </Step>
 <Step>
 Click **Save**.
 </Step>
 </Steps>
-**That's it!** Next, move on to the connector configuration instructions. 
+
+**That's it!** Next, move on to the connector configuration instructions.
 
 ## Configure the Zendesk connector
 

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -54,7 +54,7 @@ func (z *ZendeskClient) ListUsers(ctx context.Context, pageToken string) ([]zend
 		CommonOptions:    zendesk.CommonOptions{Roles: []string{teamMembersRoleAdmin, teamMembersRoleAgent}},
 	})
 	if err != nil {
-		return nil, "", err
+		return nil, "", wrapZendeskError(err)
 	}
 	return users, getNextPageToken(meta), nil
 }
@@ -66,7 +66,7 @@ func (z *ZendeskClient) ListUsersByRole(ctx context.Context, roleID int64, pageT
 		CommonOptions:    zendesk.CommonOptions{PermissionSet: roleID},
 	})
 	if err != nil {
-		return nil, "", err
+		return nil, "", wrapZendeskError(err)
 	}
 	return users, getNextPageToken(meta), nil
 }
@@ -77,7 +77,7 @@ func (z *ZendeskClient) ListGroups(ctx context.Context, pageToken string) ([]zen
 		CursorPagination: zendesk.CursorPagination{PageAfter: pageToken},
 	})
 	if err != nil {
-		return nil, "", err
+		return nil, "", wrapZendeskError(err)
 	}
 	return groups, getNextPageToken(meta), nil
 }
@@ -88,7 +88,7 @@ func (z *ZendeskClient) ListOrganizations(ctx context.Context, pageToken string)
 		CursorPagination: zendesk.CursorPagination{PageAfter: pageToken},
 	})
 	if err != nil {
-		return nil, "", err
+		return nil, "", wrapZendeskError(err)
 	}
 	return orgs, getNextPageToken(meta), nil
 }
@@ -100,7 +100,7 @@ func (z *ZendeskClient) GetGroupMemberships(ctx context.Context, groupId int64, 
 		CommonOptions:    zendesk.CommonOptions{GroupID: groupId},
 	})
 	if err != nil {
-		return nil, "", err
+		return nil, "", wrapZendeskError(err)
 	}
 	return memberships, getNextPageToken(meta), nil
 }
@@ -109,20 +109,18 @@ func (z *ZendeskClient) GetGroupMemberships(ctx context.Context, groupId int64, 
 func (z *ZendeskClient) GetUser(ctx context.Context, userID int64) (zendesk.User, error) {
 	user, err := z.client.GetUser(ctx, userID)
 	if err != nil {
-		return zendesk.User{}, err
+		return zendesk.User{}, wrapZendeskError(err)
 	}
-
-	return user, err
+	return user, nil
 }
 
 // GetGroupDetails get an existing group.
 func (z *ZendeskClient) GetGroupDetails(ctx context.Context, groupID int64) (zendesk.Group, error) {
 	group, err := z.client.GetGroup(ctx, groupID)
 	if err != nil {
-		return zendesk.Group{}, err
+		return zendesk.Group{}, wrapZendeskError(err)
 	}
-
-	return group, err
+	return group, nil
 }
 
 // GetOrgName get an existing organization name.
@@ -134,7 +132,7 @@ func (z *ZendeskClient) GetOrgName(ctx context.Context, orgID *v2.ResourceId) (s
 
 	org, err := z.client.GetOrganization(ctx, oID)
 	if err != nil {
-		return "", err
+		return "", wrapZendeskError(err)
 	}
 
 	return org.Name, nil
@@ -151,7 +149,7 @@ func (z *ZendeskClient) GetOrganizationUsers(ctx context.Context, orgID *v2.Reso
 		CommonOptions:    zendesk.CommonOptions{Id: oID, Roles: []string{teamMembersRoleAdmin, teamMembersRoleAgent}},
 	})
 	if err != nil {
-		return nil, "", err
+		return nil, "", wrapZendeskError(err)
 	}
 	return users, getNextPageToken(meta), nil
 }
@@ -215,7 +213,7 @@ func (z *ZendeskClient) CreateGroupMembership(ctx context.Context, groupMembersh
 	data.GroupMemberships = groupMemberships
 	body, err := z.client.Post(ctx, "/group_memberships.json", data)
 	if err != nil {
-		return zendesk.GroupMembership{}, err
+		return zendesk.GroupMembership{}, wrapZendeskError(err)
 	}
 
 	err = json.Unmarshal(body, &result)
@@ -233,7 +231,7 @@ func (z *ZendeskClient) GetGroupMembershipByGroup(ctx context.Context, groupMemb
 		GroupID: groupMemberships.GroupID,
 	})
 	if err != nil {
-		return "", zendesk.Page{}, err
+		return "", zendesk.Page{}, wrapZendeskError(err)
 	}
 
 	for _, group := range groups {
@@ -242,7 +240,7 @@ func (z *ZendeskClient) GetGroupMembershipByGroup(ctx context.Context, groupMemb
 		}
 	}
 
-	return "", zendesk.Page{}, err
+	return "", zendesk.Page{}, nil
 }
 
 // GetOrganizationMembershipByUser gets an existing organization membership.
@@ -252,7 +250,7 @@ func (z *ZendeskClient) GetOrganizationMembershipByUser(ctx context.Context, org
 		OrganizationID: organizationMemberships.OrganizationID,
 	})
 	if err != nil {
-		return "", zendesk.Page{}, err
+		return "", zendesk.Page{}, wrapZendeskError(err)
 	}
 
 	for _, organization := range organizations {
@@ -261,7 +259,7 @@ func (z *ZendeskClient) GetOrganizationMembershipByUser(ctx context.Context, org
 		}
 	}
 
-	return "", zendesk.Page{}, err
+	return "", zendesk.Page{}, nil
 }
 
 // RemoveGroupMembershipByID removes a user from a group, given a specified
@@ -272,13 +270,16 @@ func (z *ZendeskClient) RemoveGroupMembershipByID(ctx context.Context, groupMemb
 	if err != nil {
 		return "", err
 	}
+	if groupMembershipID == "" {
+		return "", ErrMembershipNotFound
+	}
 
 	err = z.client.Delete(ctx, fmt.Sprintf("/group_memberships/%s", groupMembershipID))
 	if err != nil {
-		return "", err
+		return "", wrapZendeskError(err)
 	}
 
-	return groupMembershipID, err
+	return groupMembershipID, nil
 }
 
 // RemoveOrganizationMembershipByID removes a user from an organization, given a specified
@@ -289,13 +290,16 @@ func (z *ZendeskClient) RemoveOrganizationMembershipByID(ctx context.Context, or
 	if err != nil {
 		return "", err
 	}
+	if organizationMembershipID == "" {
+		return "", ErrMembershipNotFound
+	}
 
 	err = z.client.Delete(ctx, fmt.Sprintf("/organization_memberships/%s", organizationMembershipID))
 	if err != nil {
-		return "", err
+		return "", wrapZendeskError(err)
 	}
 
-	return organizationMembershipID, err
+	return organizationMembershipID, nil
 }
 
 // CreateOrganizationMembership creates an organization membership for an existing user and org
@@ -307,9 +311,8 @@ func (z *ZendeskClient) CreateOrganizationMembership(ctx context.Context, opts z
 
 	data.OrganizationMembership = opts
 	body, err := z.client.Post(ctx, "/organization_memberships.json", data)
-
 	if err != nil {
-		return zendesk.OrganizationMembership{}, err
+		return zendesk.OrganizationMembership{}, wrapZendeskError(err)
 	}
 
 	err = json.Unmarshal(body, &result)
@@ -317,14 +320,14 @@ func (z *ZendeskClient) CreateOrganizationMembership(ctx context.Context, opts z
 		return zendesk.OrganizationMembership{}, err
 	}
 
-	return result.OrganizationMembership, err
+	return result.OrganizationMembership, nil
 }
 
 // GetCustomRoles fetch CustomRoles list.
 func (z *ZendeskClient) GetCustomRoles(ctx context.Context) ([]zendesk.CustomRole, error) {
 	customRole, err := z.client.GetCustomRoles(ctx)
 	if err != nil {
-		return nil, err
+		return nil, wrapZendeskError(err)
 	}
 
 	return customRole, nil
@@ -336,7 +339,11 @@ func (z *ZendeskClient) GetCustomRoles(ctx context.Context) ([]zendesk.CustomRol
 //
 // Zendesk API docs: https://developer.zendesk.com/api-reference/ticketing/users/users/#create-user
 func (z *ZendeskClient) CreateUser(ctx context.Context, user zendesk.User) (zendesk.User, error) {
-	return z.client.CreateUser(ctx, user)
+	created, err := z.client.CreateUser(ctx, user)
+	if err != nil {
+		return zendesk.User{}, wrapZendeskError(err)
+	}
+	return created, nil
 }
 
 // UpdateUser updates a user via direct HTTP PUT request with raw data.
@@ -345,7 +352,7 @@ func (z *ZendeskClient) CreateUser(ctx context.Context, user zendesk.User) (zend
 func (z *ZendeskClient) UpdateUser(ctx context.Context, userID int64, data map[string]any) (zendesk.User, error) {
 	body, err := z.client.Put(ctx, fmt.Sprintf(pathUser, userID), data)
 	if err != nil {
-		return zendesk.User{}, err
+		return zendesk.User{}, wrapZendeskError(err)
 	}
 
 	var result struct {
@@ -366,13 +373,13 @@ func (z *ZendeskClient) UpdateUser(ctx context.Context, userID int64, data map[s
 func (z *ZendeskClient) DeleteUser(ctx context.Context, userID int64) error {
 	err := z.client.Delete(ctx, fmt.Sprintf(pathUser, userID))
 	if err != nil {
-		var zErr *zendesk.Error
+		var zErr zendesk.Error
 		if ok := errors.As(err, &zErr); ok {
 			if zErr.Status() == http.StatusOK {
 				return nil
 			}
 		}
-		return err
+		return wrapZendeskError(err)
 	}
 	return nil
 }
@@ -385,13 +392,13 @@ func (z *ZendeskClient) DeleteUser(ctx context.Context, userID int64) error {
 func (z *ZendeskClient) PermanentlyDeleteUser(ctx context.Context, userID int64) error {
 	err := z.client.Delete(ctx, fmt.Sprintf(pathDeletedUser, userID))
 	if err != nil {
-		var zErr *zendesk.Error
+		var zErr zendesk.Error
 		if ok := errors.As(err, &zErr); ok {
 			if zErr.Status() == http.StatusOK {
 				return nil
 			}
 		}
-		return err
+		return wrapZendeskError(err)
 	}
 	return nil
 }

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -226,27 +226,6 @@ func (z *ZendeskClient) CreateGroupMembership(ctx context.Context, groupMembersh
 	return result.GroupMemberships, nil
 }
 
-// CreateCustomRoleMembership Assigns an agent to a given group.
-//
-// Zendesk API docs: https://developer.zendesk.com/api-reference/ticketing/account-configuration/custom_roles/#list-custom-roles
-func (z *ZendeskClient) CreateCustomRoleMembership(ctx context.Context, roleMemberships zendesk.CustomRole) (zendesk.CustomRole, error) {
-	var data, result struct {
-		CustomRoles zendesk.CustomRole `json:"custom_role"`
-	}
-
-	data.CustomRoles = roleMemberships
-	body, err := z.client.Post(ctx, "/custom_roles.json", data)
-	if err != nil {
-		return zendesk.CustomRole{}, err
-	}
-
-	err = json.Unmarshal(body, &result)
-	if err != nil {
-		return zendesk.CustomRole{}, err
-	}
-
-	return result.CustomRoles, nil
-}
 
 // GetGroupMembershipByGroup gets an existing group membership.
 func (z *ZendeskClient) GetGroupMembershipByGroup(ctx context.Context, groupMemberships zendesk.GroupMembership) (string, zendesk.Page, error) {

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -358,7 +358,6 @@ func (z *ZendeskClient) UpdateUser(ctx context.Context, userID int64, data map[s
 	return result.User, nil
 }
 
-
 // DeleteUser soft deletes a user.
 //
 // Allowed for: Admins or agents with permission to edit end-user profiles

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -226,7 +226,6 @@ func (z *ZendeskClient) CreateGroupMembership(ctx context.Context, groupMembersh
 	return result.GroupMemberships, nil
 }
 
-
 // GetGroupMembershipByGroup gets an existing group membership.
 func (z *ZendeskClient) GetGroupMembershipByGroup(ctx context.Context, groupMemberships zendesk.GroupMembership) (string, zendesk.Page, error) {
 	groups, nextPage, err := z.client.GetGroupMemberships(ctx, &zendesk.GroupMembershipListOptions{
@@ -359,28 +358,6 @@ func (z *ZendeskClient) UpdateUser(ctx context.Context, userID int64, data map[s
 	return result.User, nil
 }
 
-// UpdateUserHttp updates a user via direct HTTP PUT request (no library).
-//
-// This function is only used for enable_user action due to a bug in the Zendesk SDK
-// where the Suspended field has an omitempty JSON tag, preventing unsuspending users
-// (setting suspended=false) through the standard UpdateUser method.
-func (z *ZendeskClient) UpdateUserHttp(ctx context.Context, userID int64, payload map[string]interface{}) (zendesk.User, error) {
-	responseBody, err := z.client.Put(ctx, fmt.Sprintf(pathUser, userID), payload)
-	if err != nil {
-		return zendesk.User{}, err
-	}
-
-	var response struct {
-		User zendesk.User `json:"user"`
-	}
-
-	err = json.Unmarshal(responseBody, &response)
-	if err != nil {
-		return zendesk.User{}, err
-	}
-
-	return response.User, nil
-}
 
 // DeleteUser soft deletes a user.
 //

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -62,6 +62,21 @@ func (z *ZendeskClient) ListUsers(ctx context.Context, pageToken string) ([]zend
 	return users, "", nil
 }
 
+// ListUsersByRole returns users assigned to a specific custom role, with cursor pagination.
+func (z *ZendeskClient) ListUsersByRole(ctx context.Context, roleID int64, pageToken string) ([]zendesk.User, string, error) {
+	users, meta, err := z.client.GetUsersCBP(ctx, &zendesk.CBPOptions{
+		CursorPagination: zendesk.CursorPagination{PageAfter: pageToken},
+		CommonOptions:    zendesk.CommonOptions{PermissionSet: roleID},
+	})
+	if err != nil {
+		return nil, "", err
+	}
+	if meta.HasMore {
+		return users, meta.AfterCursor, nil
+	}
+	return users, "", nil
+}
+
 // ListGroups returns all ZendeskClient user groups.
 func (z *ZendeskClient) ListGroups(ctx context.Context, pageToken string) ([]zendesk.Group, string, error) {
 	groups, meta, err := z.client.GetGroupsCBP(ctx, &zendesk.CBPOptions{

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -88,7 +88,7 @@ func (z *ZendeskClient) ListOrganizations(ctx context.Context, pageToken string)
 		CursorPagination: zendesk.CursorPagination{PageAfter: pageToken},
 	})
 	if err != nil {
-		return nil, "", fmt.Errorf("baton-zendesk: failed to fetch org: %w", err)
+		return nil, "", err
 	}
 	return orgs, getNextPageToken(meta), nil
 }
@@ -233,7 +233,7 @@ func (z *ZendeskClient) GetGroupMembershipByGroup(ctx context.Context, groupMemb
 		GroupID: groupMemberships.GroupID,
 	})
 	if err != nil {
-		return "", zendesk.Page{}, fmt.Errorf("baton-zendesk: failed to fetch groupmembership: %w", err)
+		return "", zendesk.Page{}, err
 	}
 
 	for _, group := range groups {
@@ -252,7 +252,7 @@ func (z *ZendeskClient) GetOrganizationMembershipByUser(ctx context.Context, org
 		OrganizationID: organizationMemberships.OrganizationID,
 	})
 	if err != nil {
-		return "", zendesk.Page{}, fmt.Errorf("baton-zendesk: failed to fetch organizationmemberships: %w", err)
+		return "", zendesk.Page{}, err
 	}
 
 	for _, organization := range organizations {
@@ -324,7 +324,7 @@ func (z *ZendeskClient) CreateOrganizationMembership(ctx context.Context, opts z
 func (z *ZendeskClient) GetCustomRoles(ctx context.Context) ([]zendesk.CustomRole, error) {
 	customRole, err := z.client.GetCustomRoles(ctx)
 	if err != nil {
-		return nil, fmt.Errorf("baton-zendesk: failed to fetch customroles: %w", err)
+		return nil, err
 	}
 
 	return customRole, nil

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -56,10 +56,7 @@ func (z *ZendeskClient) ListUsers(ctx context.Context, pageToken string) ([]zend
 	if err != nil {
 		return nil, "", err
 	}
-	if meta.HasMore {
-		return users, meta.AfterCursor, nil
-	}
-	return users, "", nil
+	return users, getNextPageToken(meta), nil
 }
 
 // ListUsersByRole returns users assigned to a specific custom role, with cursor pagination.
@@ -71,10 +68,7 @@ func (z *ZendeskClient) ListUsersByRole(ctx context.Context, roleID int64, pageT
 	if err != nil {
 		return nil, "", err
 	}
-	if meta.HasMore {
-		return users, meta.AfterCursor, nil
-	}
-	return users, "", nil
+	return users, getNextPageToken(meta), nil
 }
 
 // ListGroups returns all ZendeskClient user groups.
@@ -85,10 +79,7 @@ func (z *ZendeskClient) ListGroups(ctx context.Context, pageToken string) ([]zen
 	if err != nil {
 		return nil, "", err
 	}
-	if meta.HasMore {
-		return groups, meta.AfterCursor, nil
-	}
-	return groups, "", nil
+	return groups, getNextPageToken(meta), nil
 }
 
 // ListOrganizations fetch organization list.
@@ -97,12 +88,9 @@ func (z *ZendeskClient) ListOrganizations(ctx context.Context, pageToken string)
 		CursorPagination: zendesk.CursorPagination{PageAfter: pageToken},
 	})
 	if err != nil {
-		return nil, "", fmt.Errorf("zendesk-connector: failed to fetch org: %w", err)
+		return nil, "", fmt.Errorf("baton-zendesk: failed to fetch org: %w", err)
 	}
-	if meta.HasMore {
-		return orgs, meta.AfterCursor, nil
-	}
-	return orgs, "", nil
+	return orgs, getNextPageToken(meta), nil
 }
 
 // GetGroupMemberships get the memberships of the specified group.
@@ -114,10 +102,7 @@ func (z *ZendeskClient) GetGroupMemberships(ctx context.Context, groupId int64, 
 	if err != nil {
 		return nil, "", err
 	}
-	if meta.HasMore {
-		return memberships, meta.AfterCursor, nil
-	}
-	return memberships, "", nil
+	return memberships, getNextPageToken(meta), nil
 }
 
 // GetUser get an existing user.
@@ -168,10 +153,7 @@ func (z *ZendeskClient) GetOrganizationUsers(ctx context.Context, orgID *v2.Reso
 	if err != nil {
 		return nil, "", err
 	}
-	if meta.HasMore {
-		return users, meta.AfterCursor, nil
-	}
-	return users, "", nil
+	return users, getNextPageToken(meta), nil
 }
 
 // GetUserAccountResource creates a new connector resource for a Jamf user account.
@@ -273,7 +255,7 @@ func (z *ZendeskClient) GetGroupMembershipByGroup(ctx context.Context, groupMemb
 		GroupID: groupMemberships.GroupID,
 	})
 	if err != nil {
-		return "", zendesk.Page{}, fmt.Errorf("zendesk-connector: failed to fetch groupmembership: %w", err)
+		return "", zendesk.Page{}, fmt.Errorf("baton-zendesk: failed to fetch groupmembership: %w", err)
 	}
 
 	for _, group := range groups {
@@ -292,7 +274,7 @@ func (z *ZendeskClient) GetOrganizationMembershipByUser(ctx context.Context, org
 		OrganizationID: organizationMemberships.OrganizationID,
 	})
 	if err != nil {
-		return "", zendesk.Page{}, fmt.Errorf("zendesk-connector: failed to fetch organizationmemberships: %w", err)
+		return "", zendesk.Page{}, fmt.Errorf("baton-zendesk: failed to fetch organizationmemberships: %w", err)
 	}
 
 	for _, organization := range organizations {
@@ -364,7 +346,7 @@ func (z *ZendeskClient) CreateOrganizationMembership(ctx context.Context, opts z
 func (z *ZendeskClient) GetCustomRoles(ctx context.Context) ([]zendesk.CustomRole, error) {
 	customRole, err := z.client.GetCustomRoles(ctx)
 	if err != nil {
-		return nil, fmt.Errorf("zendesk-connector: failed to fetch customroles: %w", err)
+		return nil, fmt.Errorf("baton-zendesk: failed to fetch customroles: %w", err)
 	}
 
 	return customRole, nil

--- a/pkg/client/helpers.go
+++ b/pkg/client/helpers.go
@@ -1,0 +1,10 @@
+package client
+
+import "github.com/nukosuke/go-zendesk/zendesk"
+
+func getNextPageToken(meta zendesk.CursorPaginationMeta) string {
+	if meta.HasMore {
+		return meta.AfterCursor
+	}
+	return ""
+}

--- a/pkg/client/helpers.go
+++ b/pkg/client/helpers.go
@@ -1,10 +1,50 @@
 package client
 
-import "github.com/nukosuke/go-zendesk/zendesk"
+import (
+	"errors"
+	"net/http"
+
+	"github.com/conductorone/baton-sdk/pkg/uhttp"
+	"github.com/nukosuke/go-zendesk/zendesk"
+	"google.golang.org/grpc/codes"
+)
+
+// ErrMembershipNotFound is returned when a membership lookup finds no matching record.
+var ErrMembershipNotFound = errors.New("membership not found")
 
 func getNextPageToken(meta zendesk.CursorPaginationMeta) string {
 	if meta.HasMore {
 		return meta.AfterCursor
 	}
 	return ""
+}
+
+// wrapZendeskError maps a zendesk HTTP error to a gRPC-coded error.
+// Non-zendesk errors are returned as-is.
+func wrapZendeskError(err error) error {
+	if err == nil {
+		return nil
+	}
+	var zErr zendesk.Error
+	if !errors.As(err, &zErr) {
+		return err
+	}
+	switch zErr.Status() {
+	case http.StatusUnauthorized:
+		return uhttp.WrapErrors(codes.Unauthenticated, "baton-zendesk: unauthorized", err)
+	case http.StatusForbidden:
+		return uhttp.WrapErrors(codes.PermissionDenied, "baton-zendesk: permission denied", err)
+	case http.StatusNotFound:
+		return uhttp.WrapErrors(codes.NotFound, "baton-zendesk: not found", err)
+	case http.StatusUnprocessableEntity:
+		return uhttp.WrapErrors(codes.InvalidArgument, "baton-zendesk: invalid argument", err)
+	case http.StatusTooManyRequests:
+		return uhttp.WrapErrors(codes.ResourceExhausted, "baton-zendesk: rate limit exceeded", err)
+	case http.StatusInternalServerError:
+		return uhttp.WrapErrors(codes.Internal, "baton-zendesk: internal server error", err)
+	case http.StatusServiceUnavailable:
+		return uhttp.WrapErrors(codes.Unavailable, "baton-zendesk: service unavailable", err)
+	default:
+		return uhttp.WrapErrors(codes.Unknown, "baton-zendesk: unexpected API error", err)
+	}
 }

--- a/pkg/config/conf.gen.go
+++ b/pkg/config/conf.gen.go
@@ -10,7 +10,7 @@ type Zendesk struct {
 	Orgs []string `mapstructure:"orgs"`
 }
 
-func (c* Zendesk) findFieldByTag(tagValue string) (any, bool) {
+func (c *Zendesk) findFieldByTag(tagValue string) (any, bool) {
 	v := reflect.ValueOf(c).Elem() // Dereference pointer to struct
 	t := v.Type()
 
@@ -42,11 +42,13 @@ func (c *Zendesk) GetString(fieldName string) string {
 	if !ok {
 		return ""
 	}
-	t, ok := v.(string)
-	if !ok {
-		panic("wrong type")
+	if t, ok := v.(string); ok {
+		return t
 	}
-	return t
+	if t, ok := v.([]byte); ok {
+		return string(t)
+	}
+	panic("wrong type")
 }
 
 func (c *Zendesk) GetInt(fieldName string) int {

--- a/pkg/connector/actions.go
+++ b/pkg/connector/actions.go
@@ -193,12 +193,12 @@ func (c *Connector) handleEnableUser(
 
 	l.Debug("enabling user", zap.Int64("user_id", userID))
 
-	payload := map[string]interface{}{
-		"user": map[string]interface{}{
+	payload := map[string]any{
+		"user": map[string]any{
 			"suspended": false,
 		},
 	}
-	response, err := c.zendeskClient.UpdateUserHttp(ctx, userID, payload)
+	response, err := c.zendeskClient.UpdateUser(ctx, userID, payload)
 	if err != nil {
 		var zErr *zendesk.Error
 		if ok := errors.As(err, &zErr); ok {

--- a/pkg/connector/connector.go
+++ b/pkg/connector/connector.go
@@ -23,7 +23,7 @@ func (d *Connector) ResourceSyncers(ctx context.Context) []connectorbuilder.Reso
 	return []connectorbuilder.ResourceSyncerV2{
 		groupBuilder(d.zendeskClient, d),
 		orgBuilder(d.zendeskClient, d.orgs),
-		roleBuilder(d.zendeskClient, d),
+		roleBuilder(d.zendeskClient),
 		teamMemberBuilder(d.zendeskClient, d),
 	}
 }

--- a/pkg/connector/connector.go
+++ b/pkg/connector/connector.go
@@ -3,60 +3,24 @@ package connector
 import (
 	"context"
 	"io"
-	"sync"
-	"time"
 
 	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
 	"github.com/conductorone/baton-sdk/pkg/annotations"
 	"github.com/conductorone/baton-sdk/pkg/connectorbuilder"
 	"github.com/conductorone/baton-zendesk/pkg/client"
-	"github.com/nukosuke/go-zendesk/zendesk"
 )
 
-const TTL = 5 // in minutes
-
 type Connector struct {
-	orgs           []string
-	zendeskClient  *client.ZendeskClient
-	cachedUsers    []zendesk.User
-	cacheTimestamp time.Time
-	usersMtx       sync.Mutex
-	subdomain      string
-	email          string
-	apiToken       string
+	orgs          []string
+	zendeskClient *client.ZendeskClient
+	subdomain     string
+	email         string
+	apiToken      string
 }
 
-func (c *Connector) cacheUsers(ctx context.Context) ([]zendesk.User, error) {
-	c.usersMtx.Lock()
-	defer c.usersMtx.Unlock()
-
-	if c.cachedUsers != nil && time.Since(c.cacheTimestamp) < TTL*time.Minute {
-		return c.cachedUsers, nil
-	}
-
-	var usersToCache []zendesk.User
-	pageToken := ""
-	for {
-		users, nextPageToken, err := c.zendeskClient.ListUsers(ctx, pageToken)
-		if err != nil {
-			return nil, err
-		}
-		usersToCache = append(usersToCache, users...)
-
-		if nextPageToken == "" {
-			break
-		}
-		pageToken = nextPageToken
-	}
-
-	c.cachedUsers = usersToCache
-	c.cacheTimestamp = time.Now()
-	return usersToCache, nil
-}
-
-// ResourceSyncers returns a ResourceSyncer for each resource type that should be synced from the upstream service.
-func (d *Connector) ResourceSyncers(ctx context.Context) []connectorbuilder.ResourceSyncer {
-	return []connectorbuilder.ResourceSyncer{
+// ResourceSyncers returns a ResourceSyncerV2 for each resource type that should be synced from the upstream service.
+func (d *Connector) ResourceSyncers(ctx context.Context) []connectorbuilder.ResourceSyncerV2 {
+	return []connectorbuilder.ResourceSyncerV2{
 		groupBuilder(d.zendeskClient, d),
 		orgBuilder(d.zendeskClient, d.orgs),
 		roleBuilder(d.zendeskClient, d),

--- a/pkg/connector/connector.go
+++ b/pkg/connector/connector.go
@@ -21,10 +21,10 @@ type Connector struct {
 // ResourceSyncers returns a ResourceSyncerV2 for each resource type that should be synced from the upstream service.
 func (d *Connector) ResourceSyncers(ctx context.Context) []connectorbuilder.ResourceSyncerV2 {
 	return []connectorbuilder.ResourceSyncerV2{
-		groupBuilder(d.zendeskClient, d),
+		groupBuilder(d.zendeskClient),
 		orgBuilder(d.zendeskClient, d.orgs),
 		roleBuilder(d.zendeskClient),
-		teamMemberBuilder(d.zendeskClient, d),
+		teamMemberBuilder(d.zendeskClient),
 	}
 }
 

--- a/pkg/connector/connector.go
+++ b/pkg/connector/connector.go
@@ -28,6 +28,11 @@ func (d *Connector) ResourceSyncers(ctx context.Context) []connectorbuilder.Reso
 	}
 }
 
+// Close cleans up any resources held by the connector.
+func (d *Connector) Close() error {
+	return nil
+}
+
 // Asset takes an input AssetRef and attempts to fetch it using the connector's authenticated http client
 // It streams a response, always starting with a metadata object, following by chunked payloads for the asset.
 func (d *Connector) Asset(ctx context.Context, asset *v2.AssetRef) (string, io.ReadCloser, error) {
@@ -38,7 +43,7 @@ func (d *Connector) Asset(ctx context.Context, asset *v2.AssetRef) (string, io.R
 func (d *Connector) Metadata(ctx context.Context) (*v2.ConnectorMetadata, error) {
 	return &v2.ConnectorMetadata{
 		DisplayName: "Zendesk Connector",
-		Description: "Connector syncing users, groups, and roles from Zendesk..",
+		Description: "Connector syncing users, groups, and roles from Zendesk.",
 		AccountCreationSchema: &v2.ConnectorAccountCreationSchema{
 			FieldMap: map[string]*v2.ConnectorAccountCreationSchema_Field{
 				"name": {

--- a/pkg/connector/connector_cache.go
+++ b/pkg/connector/connector_cache.go
@@ -2,7 +2,6 @@ package connector
 
 import (
 	"context"
-	"fmt"
 	"strconv"
 
 	"github.com/conductorone/baton-sdk/pkg/session"
@@ -30,9 +29,12 @@ func (c *Connector) getCachedUsersByIDs(ctx context.Context, ss sessions.Session
 	if ss == nil {
 		return nil, nil
 	}
+	keyToID := make(map[string]int64, len(userIDs))
 	keys := make([]string, len(userIDs))
 	for i, id := range userIDs {
-		keys[i] = strconv.FormatInt(id, 10)
+		k := strconv.FormatInt(id, 10)
+		keys[i] = k
+		keyToID[k] = id
 	}
 	cached, err := session.GetManyJSON[zendesk.User](ctx, ss, keys, usersNamespace)
 	if err != nil {
@@ -40,11 +42,7 @@ func (c *Connector) getCachedUsersByIDs(ctx context.Context, ss sessions.Session
 	}
 	users := make(map[int64]zendesk.User, len(cached))
 	for k, u := range cached {
-		id, err := strconv.ParseInt(k, 10, 64)
-		if err != nil {
-			return nil, fmt.Errorf("invalid user ID key in cache %q: %w", k, err)
-		}
-		users[id] = u
+		users[keyToID[k]] = u
 	}
 	return users, nil
 }

--- a/pkg/connector/connector_cache.go
+++ b/pkg/connector/connector_cache.go
@@ -2,6 +2,7 @@ package connector
 
 import (
 	"context"
+	"fmt"
 	"strconv"
 
 	"github.com/conductorone/baton-sdk/pkg/session"
@@ -27,7 +28,7 @@ func populateCache(ctx context.Context, ss sessions.SessionStore, users []zendes
 // getCachedUsersByIDs fetches only the specified users from the session store.
 func getCachedUsersByIDs(ctx context.Context, ss sessions.SessionStore, userIDs []int64) (map[int64]zendesk.User, error) {
 	if ss == nil {
-		return nil, nil
+		return nil, fmt.Errorf("baton-zendesk: session store is nil, cannot fetch cached users")
 	}
 	keyToID := make(map[string]int64, len(userIDs))
 	keys := make([]string, len(userIDs))

--- a/pkg/connector/connector_cache.go
+++ b/pkg/connector/connector_cache.go
@@ -20,7 +20,7 @@ func (c *Connector) populateCache(ctx context.Context, ss sessions.SessionStore,
 	}
 	userMap := make(map[string]zendesk.User, len(users))
 	for _, user := range users {
-		userMap[fmt.Sprintf("%d", user.ID)] = user
+		userMap[strconv.FormatInt(user.ID, 10)] = user
 	}
 	return session.SetManyJSON(ctx, ss, userMap, usersNamespace)
 }
@@ -32,7 +32,7 @@ func (c *Connector) getCachedUsersByIDs(ctx context.Context, ss sessions.Session
 	}
 	keys := make([]string, len(userIDs))
 	for i, id := range userIDs {
-		keys[i] = fmt.Sprintf("%d", id)
+		keys[i] = strconv.FormatInt(id, 10)
 	}
 	cached, err := session.GetManyJSON[zendesk.User](ctx, ss, keys, usersNamespace)
 	if err != nil {

--- a/pkg/connector/connector_cache.go
+++ b/pkg/connector/connector_cache.go
@@ -1,0 +1,67 @@
+package connector
+
+import (
+	"context"
+	"sort"
+	"strconv"
+
+	"github.com/conductorone/baton-sdk/pkg/session"
+	"github.com/conductorone/baton-sdk/pkg/types/sessions"
+	"github.com/nukosuke/go-zendesk/zendesk"
+)
+
+var usersNamespace = sessions.WithPrefix("zendesk:users")
+
+func (c *Connector) cacheUsers(ctx context.Context, ss sessions.SessionStore) ([]zendesk.User, error) {
+	if ss != nil {
+		cached, err := session.GetAllJSON[zendesk.User](ctx, ss, usersNamespace)
+		if err == nil && len(cached) > 0 {
+			indices := make([]int, 0, len(cached))
+			for k := range cached {
+				i, err := strconv.Atoi(k)
+				if err != nil {
+					users := make([]zendesk.User, 0, len(cached))
+					for _, u := range cached {
+						users = append(users, u)
+					}
+					return users, nil
+				}
+				indices = append(indices, i)
+			}
+			sort.Ints(indices)
+			users := make([]zendesk.User, 0, len(indices))
+			for _, i := range indices {
+				if u, ok := cached[strconv.Itoa(i)]; ok {
+					users = append(users, u)
+				}
+			}
+			return users, nil
+		}
+	}
+
+	var usersToCache []zendesk.User
+	pageToken := ""
+	for {
+		users, nextPageToken, err := c.zendeskClient.ListUsers(ctx, pageToken)
+		if err != nil {
+			return nil, err
+		}
+		usersToCache = append(usersToCache, users...)
+		if nextPageToken == "" {
+			break
+		}
+		pageToken = nextPageToken
+	}
+
+	if ss != nil && len(usersToCache) > 0 {
+		userMap := make(map[string]zendesk.User, len(usersToCache))
+		for i, user := range usersToCache {
+			userMap[strconv.Itoa(i)] = user
+		}
+		if err := session.SetManyJSON(ctx, ss, userMap, usersNamespace); err != nil {
+			return nil, err
+		}
+	}
+
+	return usersToCache, nil
+}

--- a/pkg/connector/connector_cache.go
+++ b/pkg/connector/connector_cache.go
@@ -13,7 +13,7 @@ var usersNamespace = sessions.WithPrefix("zendesk:users")
 
 // populateCache stores a page of users into the session store, keyed by user ID.
 // Called from team_member.List on each page so the cache is built incrementally during resource sync.
-func (c *Connector) populateCache(ctx context.Context, ss sessions.SessionStore, users []zendesk.User) error {
+func populateCache(ctx context.Context, ss sessions.SessionStore, users []zendesk.User) error {
 	if ss == nil || len(users) == 0 {
 		return nil
 	}
@@ -25,7 +25,7 @@ func (c *Connector) populateCache(ctx context.Context, ss sessions.SessionStore,
 }
 
 // getCachedUsersByIDs fetches only the specified users from the session store.
-func (c *Connector) getCachedUsersByIDs(ctx context.Context, ss sessions.SessionStore, userIDs []int64) (map[int64]zendesk.User, error) {
+func getCachedUsersByIDs(ctx context.Context, ss sessions.SessionStore, userIDs []int64) (map[int64]zendesk.User, error) {
 	if ss == nil {
 		return nil, nil
 	}

--- a/pkg/connector/connector_cache.go
+++ b/pkg/connector/connector_cache.go
@@ -2,7 +2,7 @@ package connector
 
 import (
 	"context"
-	"sort"
+	"fmt"
 	"strconv"
 
 	"github.com/conductorone/baton-sdk/pkg/session"
@@ -12,56 +12,39 @@ import (
 
 var usersNamespace = sessions.WithPrefix("zendesk:users")
 
-func (c *Connector) cacheUsers(ctx context.Context, ss sessions.SessionStore) ([]zendesk.User, error) {
-	if ss != nil {
-		cached, err := session.GetAllJSON[zendesk.User](ctx, ss, usersNamespace)
-		if err == nil && len(cached) > 0 {
-			indices := make([]int, 0, len(cached))
-			for k := range cached {
-				i, err := strconv.Atoi(k)
-				if err != nil {
-					users := make([]zendesk.User, 0, len(cached))
-					for _, u := range cached {
-						users = append(users, u)
-					}
-					return users, nil
-				}
-				indices = append(indices, i)
-			}
-			sort.Ints(indices)
-			users := make([]zendesk.User, 0, len(indices))
-			for _, i := range indices {
-				if u, ok := cached[strconv.Itoa(i)]; ok {
-					users = append(users, u)
-				}
-			}
-			return users, nil
-		}
+// populateCache stores a page of users into the session store, keyed by user ID.
+// Called from team_member.List on each page so the cache is built incrementally during resource sync.
+func (c *Connector) populateCache(ctx context.Context, ss sessions.SessionStore, users []zendesk.User) error {
+	if ss == nil || len(users) == 0 {
+		return nil
 	}
+	userMap := make(map[string]zendesk.User, len(users))
+	for _, user := range users {
+		userMap[fmt.Sprintf("%d", user.ID)] = user
+	}
+	return session.SetManyJSON(ctx, ss, userMap, usersNamespace)
+}
 
-	var usersToCache []zendesk.User
-	pageToken := ""
-	for {
-		users, nextPageToken, err := c.zendeskClient.ListUsers(ctx, pageToken)
+// getCachedUsersByIDs fetches only the specified users from the session store.
+func (c *Connector) getCachedUsersByIDs(ctx context.Context, ss sessions.SessionStore, userIDs []int64) (map[int64]zendesk.User, error) {
+	if ss == nil {
+		return nil, nil
+	}
+	keys := make([]string, len(userIDs))
+	for i, id := range userIDs {
+		keys[i] = fmt.Sprintf("%d", id)
+	}
+	cached, err := session.GetManyJSON[zendesk.User](ctx, ss, keys, usersNamespace)
+	if err != nil {
+		return nil, err
+	}
+	users := make(map[int64]zendesk.User, len(cached))
+	for k, u := range cached {
+		id, err := strconv.ParseInt(k, 10, 64)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("invalid user ID key in cache %q: %w", k, err)
 		}
-		usersToCache = append(usersToCache, users...)
-		if nextPageToken == "" {
-			break
-		}
-		pageToken = nextPageToken
+		users[id] = u
 	}
-
-	if ss != nil && len(usersToCache) > 0 {
-		userMap := make(map[string]zendesk.User, len(usersToCache))
-		for i, user := range usersToCache {
-			userMap[strconv.Itoa(i)] = user
-		}
-		if err := session.SetManyJSON(ctx, ss, userMap, usersNamespace); err != nil {
-			return nil, err
-		}
-	}
-
-	return usersToCache, nil
+	return users, nil
 }

--- a/pkg/connector/group.go
+++ b/pkg/connector/group.go
@@ -24,7 +24,6 @@ const (
 type groupResourceType struct {
 	resourceType *v2.ResourceType
 	client       *client.ZendeskClient
-	connector    *Connector
 }
 
 var groupEntitlementAccessLevels = []string{
@@ -79,12 +78,12 @@ func (g *groupResourceType) Entitlements(_ context.Context, resource *v2.Resourc
 
 func (g *groupResourceType) Grants(ctx context.Context, resource *v2.Resource, opts rs.SyncOpAttrs) ([]*v2.Grant, *rs.SyncOpResults, error) {
 	var rv []*v2.Grant
-	groupId, err := strconv.Atoi(resource.Id.Resource)
+	groupId, err := strconv.ParseInt(resource.Id.Resource, 10, 64)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	groupMemberships, nextPageToken, err := g.client.GetGroupMemberships(ctx, int64(groupId), opts.PageToken.Token)
+	groupMemberships, nextPageToken, err := g.client.GetGroupMemberships(ctx, groupId, opts.PageToken.Token)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -94,7 +93,7 @@ func (g *groupResourceType) Grants(ctx context.Context, resource *v2.Resource, o
 		memberIDs[i] = m.UserID
 	}
 
-	mapUsers, err := g.connector.getCachedUsersByIDs(ctx, opts.Session, memberIDs)
+	mapUsers, err := getCachedUsersByIDs(ctx, opts.Session, memberIDs)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -212,10 +211,9 @@ func (g *groupResourceType) Revoke(ctx context.Context, grant *v2.Grant) (annota
 	return nil, nil
 }
 
-func groupBuilder(cli *client.ZendeskClient, con *Connector) *groupResourceType {
+func groupBuilder(cli *client.ZendeskClient) *groupResourceType {
 	return &groupResourceType{
 		resourceType: resourceTypeGroup,
 		client:       cli,
-		connector:    con,
 	}
 }

--- a/pkg/connector/group.go
+++ b/pkg/connector/group.go
@@ -101,11 +101,18 @@ func (g *groupResourceType) Grants(ctx context.Context, resource *v2.Resource, o
 	}
 
 	for _, membership := range groupMemberships {
-		user := getUserByID(membership.UserID, mapUsers)
-		if user.ID == 0 {
-			l.Debug("skipping group membership: user not found in cache", zap.Int64("userID", membership.UserID), zap.String("groupID", resource.Id.Resource))
-			continue
+		user, err := getUserByID(membership.UserID, mapUsers)
+		if err != nil {
+			l.Debug("baton-zendesk: user not in cache, fetching from API", zap.Int64("userID", membership.UserID))
+			user, err = g.client.GetUser(ctx, membership.UserID)
+			if err != nil {
+				return nil, nil, fmt.Errorf("baton-zendesk: failed to get user %d: %w", membership.UserID, err)
+			}
+			if err = populateCache(ctx, opts.Session, []zendesk.User{user}); err != nil {
+				l.Debug("baton-zendesk: failed to populate cache for user", zap.Int64("userID", membership.UserID), zap.Error(err))
+			}
 		}
+
 		ur, err := getUserResource(user, resourceTypeTeam)
 		if err != nil {
 			return nil, nil, fmt.Errorf("error creating team_member resource for group %s: %w", resource.Id.Resource, err)

--- a/pkg/connector/group.go
+++ b/pkg/connector/group.go
@@ -80,6 +80,8 @@ func (g *groupResourceType) Entitlements(_ context.Context, resource *v2.Resourc
 func (g *groupResourceType) Grants(ctx context.Context, resource *v2.Resource, opts rs.SyncOpAttrs) ([]*v2.Grant, *rs.SyncOpResults, error) {
 	l := ctxzap.Extract(ctx)
 	var rv []*v2.Grant
+	var usersToCache []zendesk.User
+
 	groupId, err := strconv.ParseInt(resource.Id.Resource, 10, 64)
 	if err != nil {
 		return nil, nil, err
@@ -108,9 +110,7 @@ func (g *groupResourceType) Grants(ctx context.Context, resource *v2.Resource, o
 			if err != nil {
 				return nil, nil, fmt.Errorf("baton-zendesk: failed to get user %d: %w", membership.UserID, err)
 			}
-			if err = populateCache(ctx, opts.Session, []zendesk.User{user}); err != nil {
-				l.Debug("baton-zendesk: failed to populate cache for user", zap.Int64("userID", membership.UserID), zap.Error(err))
-			}
+			usersToCache = append(usersToCache, user)
 		}
 
 		ur, err := getUserResource(user, resourceTypeTeam)
@@ -123,6 +123,12 @@ func (g *groupResourceType) Grants(ctx context.Context, resource *v2.Resource, o
 		}
 
 		rv = append(rv, grant.NewGrant(resource, memberEntitlement, ur.Id))
+	}
+
+	if len(usersToCache) > 0 {
+		if err = populateCache(ctx, opts.Session, usersToCache); err != nil {
+			l.Debug("baton-zendesk: failed to populate cache for users on group grants")
+		}
 	}
 
 	return rv, &rs.SyncOpResults{NextPageToken: nextPageToken}, nil

--- a/pkg/connector/group.go
+++ b/pkg/connector/group.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"strconv"
+	"strings"
 
 	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
 	"github.com/conductorone/baton-sdk/pkg/annotations"
@@ -45,7 +46,7 @@ func (g *groupResourceType) List(ctx context.Context, parentId *v2.ResourceId, o
 
 	groups, nextPageToken, err := g.client.ListGroups(ctx, opts.PageToken.Token)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, fmt.Errorf("baton-zendesk: failed to list groups: %w", err)
 	}
 
 	for _, group := range groups {
@@ -86,7 +87,7 @@ func (g *groupResourceType) Grants(ctx context.Context, resource *v2.Resource, o
 
 	groupMemberships, nextPageToken, err := g.client.GetGroupMemberships(ctx, groupId, opts.PageToken.Token)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, fmt.Errorf("baton-zendesk: failed to list group memberships: %w", err)
 	}
 
 	memberIDs := make([]int64, len(groupMemberships))
@@ -110,7 +111,7 @@ func (g *groupResourceType) Grants(ctx context.Context, resource *v2.Resource, o
 			return nil, nil, fmt.Errorf("error creating team_member resource for group %s: %w", resource.Id.Resource, err)
 		}
 
-		if user.Role == adminEntitlement {
+		if strings.ToLower(user.Role) == adminEntitlement {
 			rv = append(rv, grant.NewGrant(resource, adminEntitlement, ur.Id))
 		}
 
@@ -138,7 +139,7 @@ func (g *groupResourceType) Grant(ctx context.Context, principal *v2.Resource, e
 
 	user, err := g.client.GetUser(ctx, userID)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, fmt.Errorf("baton-zendesk: failed to get user %d: %w", userID, err)
 	}
 	if user.Role == zendesk.UserRoleText(zendesk.UserRoleEndUser) {
 		l.Warn("user must be a team member",

--- a/pkg/connector/group.go
+++ b/pkg/connector/group.go
@@ -7,9 +7,9 @@ import (
 
 	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
 	"github.com/conductorone/baton-sdk/pkg/annotations"
-	"github.com/conductorone/baton-sdk/pkg/pagination"
 	ent "github.com/conductorone/baton-sdk/pkg/types/entitlement"
 	"github.com/conductorone/baton-sdk/pkg/types/grant"
+	rs "github.com/conductorone/baton-sdk/pkg/types/resource"
 	"github.com/conductorone/baton-zendesk/pkg/client"
 	"github.com/grpc-ecosystem/go-grpc-middleware/logging/zap/ctxzap"
 	"github.com/nukosuke/go-zendesk/zendesk"
@@ -38,30 +38,30 @@ func (g *groupResourceType) ResourceType(_ context.Context) *v2.ResourceType {
 
 // List returns all the groups from the database as resource objects.
 // Groups include a GroupTrait because they are the 'shape' of a standard group.
-func (g *groupResourceType) List(ctx context.Context, parentId *v2.ResourceId, pToken *pagination.Token) ([]*v2.Resource, string, annotations.Annotations, error) {
+func (g *groupResourceType) List(ctx context.Context, parentId *v2.ResourceId, opts rs.SyncOpAttrs) ([]*v2.Resource, *rs.SyncOpResults, error) {
 	var (
 		err error
 		ret []*v2.Resource
 	)
 
-	groups, nextPageToken, err := g.client.ListGroups(ctx, pToken.Token)
+	groups, nextPageToken, err := g.client.ListGroups(ctx, opts.PageToken.Token)
 	if err != nil {
-		return nil, "", nil, err
+		return nil, nil, err
 	}
 
 	for _, group := range groups {
 		res, err := getGroupResource(group, resourceTypeGroup, parentId)
 		if err != nil {
-			return nil, "", nil, err
+			return nil, nil, err
 		}
 
 		ret = append(ret, res)
 	}
 
-	return ret, nextPageToken, nil, nil
+	return ret, &rs.SyncOpResults{NextPageToken: nextPageToken}, nil
 }
 
-func (g *groupResourceType) Entitlements(_ context.Context, resource *v2.Resource, _ *pagination.Token) ([]*v2.Entitlement, string, annotations.Annotations, error) {
+func (g *groupResourceType) Entitlements(_ context.Context, resource *v2.Resource, _ rs.SyncOpAttrs) ([]*v2.Entitlement, *rs.SyncOpResults, error) {
 	var rv []*v2.Entitlement
 	for _, level := range groupEntitlementAccessLevels {
 		rv = append(rv, ent.NewPermissionEntitlement(resource, level,
@@ -74,35 +74,36 @@ func (g *groupResourceType) Entitlements(_ context.Context, resource *v2.Resourc
 		))
 	}
 
-	return rv, "", nil, nil
+	return rv, nil, nil
 }
 
-func (g *groupResourceType) Grants(ctx context.Context, resource *v2.Resource, token *pagination.Token) ([]*v2.Grant, string, annotations.Annotations, error) {
+func (g *groupResourceType) Grants(ctx context.Context, resource *v2.Resource, opts rs.SyncOpAttrs) ([]*v2.Grant, *rs.SyncOpResults, error) {
 	var rv []*v2.Grant
 	groupId, err := strconv.Atoi(resource.Id.Resource)
 	if err != nil {
-		return nil, "", nil, err
+		return nil, nil, err
 	}
 
-	users, err := g.connector.cacheUsers(ctx)
+	// TODO: luisina - review cache handling
+	users, err := g.connector.cacheUsers(ctx, opts.Session)
 	mapUsers := make(map[int64]zendesk.User)
 	for _, user := range users {
 		mapUsers[user.ID] = user
 	}
 	if err != nil {
-		return nil, "", nil, err
+		return nil, nil, err
 	}
 
-	groupMemberships, nextPageToken, err := g.client.GetGroupMemberships(ctx, int64(groupId), token.Token)
+	groupMemberships, nextPageToken, err := g.client.GetGroupMemberships(ctx, int64(groupId), opts.PageToken.Token)
 	if err != nil {
-		return nil, "", nil, err
+		return nil, nil, err
 	}
 
 	for _, group := range groupMemberships {
 		userAccountDetail := getUserByID(group.UserID, mapUsers)
 		ur, err := getUserResource(userAccountDetail, resourceTypeTeam)
 		if err != nil {
-			return nil, "", nil, fmt.Errorf("error creating team_member resource for group %s: %w", resource.Id.Resource, err)
+			return nil, nil, fmt.Errorf("error creating team_member resource for group %s: %w", resource.Id.Resource, err)
 		}
 
 		if userAccountDetail.Role == adminEntitlement {
@@ -116,10 +117,10 @@ func (g *groupResourceType) Grants(ctx context.Context, resource *v2.Resource, t
 		rv = append(rv, membershipGrant, teamMembershipGrant)
 	}
 
-	return rv, nextPageToken, nil, nil
+	return rv, &rs.SyncOpResults{NextPageToken: nextPageToken}, nil
 }
 
-func (g *groupResourceType) Grant(ctx context.Context, principal *v2.Resource, entitlement *v2.Entitlement) (annotations.Annotations, error) {
+func (g *groupResourceType) Grant(ctx context.Context, principal *v2.Resource, entitlement *v2.Entitlement) ([]*v2.Grant, annotations.Annotations, error) {
 	l := ctxzap.Extract(ctx)
 	if principal.Id.ResourceType != resourceTypeTeam.Id {
 		l.Warn(
@@ -127,29 +128,29 @@ func (g *groupResourceType) Grant(ctx context.Context, principal *v2.Resource, e
 			zap.String("principal_type", principal.Id.ResourceType),
 			zap.String("principal_id", principal.Id.Resource),
 		)
-		return nil, fmt.Errorf("zendesk-connector: only users can be granted team membership")
+		return nil, nil, fmt.Errorf("zendesk-connector: only users can be granted team membership")
 	}
 
 	userID, err := strconv.ParseInt(principal.Id.Resource, 10, 64)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	user, err := g.client.GetUser(ctx, userID)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	if user.Role == "end-user" {
 		l.Warn("user must be a team member",
 			zap.Int64("UserID", user.ID),
 			zap.String("user.Role", user.Role),
 		)
-		return nil, fmt.Errorf("user must be a team member")
+		return nil, nil, fmt.Errorf("user must be a team member")
 	}
 
 	groupID, err := strconv.ParseInt(entitlement.Resource.Id.Resource, 10, 64)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	groupMembershipOptions := zendesk.GroupMembership{
@@ -158,7 +159,7 @@ func (g *groupResourceType) Grant(ctx context.Context, principal *v2.Resource, e
 	}
 	membership, err := g.client.CreateGroupMembership(ctx, groupMembershipOptions)
 	if err != nil {
-		return nil, fmt.Errorf("zendesk-connector: failed to add team member to a group: %s", err.Error())
+		return nil, nil, fmt.Errorf("zendesk-connector: failed to add team member to a group: %s", err.Error())
 	}
 
 	l.Warn("Membership has been created.",
@@ -168,7 +169,7 @@ func (g *groupResourceType) Grant(ctx context.Context, principal *v2.Resource, e
 		zap.Time("CreatedAt", membership.CreatedAt),
 	)
 
-	return nil, nil
+	return nil, nil, nil
 }
 
 func (g *groupResourceType) Revoke(ctx context.Context, grant *v2.Grant) (annotations.Annotations, error) {

--- a/pkg/connector/group.go
+++ b/pkg/connector/group.go
@@ -120,11 +120,11 @@ func (g *groupResourceType) Grant(ctx context.Context, principal *v2.Resource, e
 	l := ctxzap.Extract(ctx)
 	if principal.Id.ResourceType != resourceTypeTeam.Id {
 		l.Warn(
-			"zendesk-connector: only team members can be granted group membership",
+			"baton-zendesk: only team members can be granted group membership",
 			zap.String("principal_type", principal.Id.ResourceType),
 			zap.String("principal_id", principal.Id.Resource),
 		)
-		return nil, nil, fmt.Errorf("zendesk-connector: only users can be granted team membership")
+		return nil, nil, fmt.Errorf("baton-zendesk: only users can be granted team membership")
 	}
 
 	userID, err := strconv.ParseInt(principal.Id.Resource, 10, 64)
@@ -136,7 +136,7 @@ func (g *groupResourceType) Grant(ctx context.Context, principal *v2.Resource, e
 	if err != nil {
 		return nil, nil, err
 	}
-	if user.Role == "end-user" {
+	if user.Role == zendesk.UserRoleText(zendesk.UserRoleEndUser) {
 		l.Warn("user must be a team member",
 			zap.Int64("UserID", user.ID),
 			zap.String("user.Role", user.Role),
@@ -155,7 +155,7 @@ func (g *groupResourceType) Grant(ctx context.Context, principal *v2.Resource, e
 	}
 	membership, err := g.client.CreateGroupMembership(ctx, groupMembershipOptions)
 	if err != nil {
-		return nil, nil, fmt.Errorf("zendesk-connector: failed to add team member to a group: %s", err.Error())
+		return nil, nil, fmt.Errorf("baton-zendesk: failed to add team member to a group: %w", err)
 	}
 
 	l.Warn("Membership has been created.",
@@ -176,11 +176,11 @@ func (g *groupResourceType) Revoke(ctx context.Context, grant *v2.Grant) (annota
 
 	if principal.Id.ResourceType != resourceTypeTeam.Id {
 		l.Warn(
-			"zendesk-connector: only team members can have group membership revoked",
+			"baton-zendesk: only team members can have group membership revoked",
 			zap.String("principal_type", principal.Id.ResourceType),
 			zap.String("principal_id", principal.Id.Resource),
 		)
-		return nil, fmt.Errorf("zendesk-connector: only team members can have group membership revoked")
+		return nil, fmt.Errorf("baton-zendesk: only team members can have group membership revoked")
 	}
 
 	userID, err := strconv.ParseInt(principal.Id.Resource, 10, 64)
@@ -199,7 +199,7 @@ func (g *groupResourceType) Revoke(ctx context.Context, grant *v2.Grant) (annota
 	}
 	groupMembershipID, err := g.client.RemoveGroupMembershipByID(ctx, groupMembershipOptions)
 	if err != nil {
-		return nil, fmt.Errorf("zendesk-connector: failed to revoke team member: %s", err.Error())
+		return nil, fmt.Errorf("baton-zendesk: failed to revoke team member: %w", err)
 	}
 
 	l.Warn("Membership has been revoked..",

--- a/pkg/connector/group.go
+++ b/pkg/connector/group.go
@@ -84,29 +84,29 @@ func (g *groupResourceType) Grants(ctx context.Context, resource *v2.Resource, o
 		return nil, nil, err
 	}
 
-	// TODO: luisina - review cache handling
-	users, err := g.connector.cacheUsers(ctx, opts.Session)
-	mapUsers := make(map[int64]zendesk.User)
-	for _, user := range users {
-		mapUsers[user.ID] = user
-	}
-	if err != nil {
-		return nil, nil, err
-	}
-
 	groupMemberships, nextPageToken, err := g.client.GetGroupMemberships(ctx, int64(groupId), opts.PageToken.Token)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	for _, group := range groupMemberships {
-		userAccountDetail := getUserByID(group.UserID, mapUsers)
-		ur, err := getUserResource(userAccountDetail, resourceTypeTeam)
+	memberIDs := make([]int64, len(groupMemberships))
+	for i, m := range groupMemberships {
+		memberIDs[i] = m.UserID
+	}
+
+	mapUsers, err := g.connector.getCachedUsersByIDs(ctx, opts.Session, memberIDs)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	for _, membership := range groupMemberships {
+		user := getUserByID(membership.UserID, mapUsers)
+		ur, err := getUserResource(user, resourceTypeTeam)
 		if err != nil {
 			return nil, nil, fmt.Errorf("error creating team_member resource for group %s: %w", resource.Id.Resource, err)
 		}
 
-		if userAccountDetail.Role == adminEntitlement {
+		if user.Role == adminEntitlement {
 			adminsGrant := grant.NewGrant(resource, adminEntitlement, ur.Id)
 			teamAdminsGrant := grant.NewGrant(ur, adminEntitlement, resource.Id)
 			rv = append(rv, adminsGrant, teamAdminsGrant)

--- a/pkg/connector/group.go
+++ b/pkg/connector/group.go
@@ -107,14 +107,10 @@ func (g *groupResourceType) Grants(ctx context.Context, resource *v2.Resource, o
 		}
 
 		if user.Role == adminEntitlement {
-			adminsGrant := grant.NewGrant(resource, adminEntitlement, ur.Id)
-			teamAdminsGrant := grant.NewGrant(ur, adminEntitlement, resource.Id)
-			rv = append(rv, adminsGrant, teamAdminsGrant)
+			rv = append(rv, grant.NewGrant(resource, adminEntitlement, ur.Id))
 		}
 
-		membershipGrant := grant.NewGrant(resource, memberEntitlement, ur.Id)
-		teamMembershipGrant := grant.NewGrant(ur, memberEntitlement, resource.Id)
-		rv = append(rv, membershipGrant, teamMembershipGrant)
+		rv = append(rv, grant.NewGrant(resource, memberEntitlement, ur.Id))
 	}
 
 	return rv, &rs.SyncOpResults{NextPageToken: nextPageToken}, nil

--- a/pkg/connector/group.go
+++ b/pkg/connector/group.go
@@ -101,6 +101,9 @@ func (g *groupResourceType) Grants(ctx context.Context, resource *v2.Resource, o
 
 	for _, membership := range groupMemberships {
 		user := getUserByID(membership.UserID, mapUsers)
+		if user.ID == 0 {
+			continue
+		}
 		ur, err := getUserResource(user, resourceTypeTeam)
 		if err != nil {
 			return nil, nil, fmt.Errorf("error creating team_member resource for group %s: %w", resource.Id.Resource, err)
@@ -158,7 +161,7 @@ func (g *groupResourceType) Grant(ctx context.Context, principal *v2.Resource, e
 		return nil, nil, fmt.Errorf("baton-zendesk: failed to add team member to a group: %w", err)
 	}
 
-	l.Warn("Membership has been created.",
+	l.Debug("Membership has been created.",
 		zap.Int64("ID", membership.ID),
 		zap.Int64("UserID", membership.UserID),
 		zap.Int64("GroupID", membership.GroupID),
@@ -202,7 +205,7 @@ func (g *groupResourceType) Revoke(ctx context.Context, grant *v2.Grant) (annota
 		return nil, fmt.Errorf("baton-zendesk: failed to revoke team member: %w", err)
 	}
 
-	l.Warn("Membership has been revoked..",
+	l.Debug("Membership has been revoked.",
 		zap.String("groupMembershipID", groupMembershipID),
 	)
 

--- a/pkg/connector/group.go
+++ b/pkg/connector/group.go
@@ -77,6 +77,7 @@ func (g *groupResourceType) Entitlements(_ context.Context, resource *v2.Resourc
 }
 
 func (g *groupResourceType) Grants(ctx context.Context, resource *v2.Resource, opts rs.SyncOpAttrs) ([]*v2.Grant, *rs.SyncOpResults, error) {
+	l := ctxzap.Extract(ctx)
 	var rv []*v2.Grant
 	groupId, err := strconv.ParseInt(resource.Id.Resource, 10, 64)
 	if err != nil {
@@ -101,6 +102,7 @@ func (g *groupResourceType) Grants(ctx context.Context, resource *v2.Resource, o
 	for _, membership := range groupMemberships {
 		user := getUserByID(membership.UserID, mapUsers)
 		if user.ID == 0 {
+			l.Debug("skipping group membership: user not found in cache", zap.Int64("userID", membership.UserID), zap.String("groupID", resource.Id.Resource))
 			continue
 		}
 		ur, err := getUserResource(user, resourceTypeTeam)

--- a/pkg/connector/helpers.go
+++ b/pkg/connector/helpers.go
@@ -164,13 +164,13 @@ func getUserResource(user zendesk.User, resourceTypeUser *v2.ResourceType) (*v2.
 	return resource, nil
 }
 
-// getUserByID gets an user by ID.
-func getUserByID(userID int64, users map[int64]zendesk.User) zendesk.User {
+// getUserByID looks up a user by ID in the provided map.
+// Returns an error if the user is not found, so the caller can fall back to a live API call.
+func getUserByID(userID int64, users map[int64]zendesk.User) (zendesk.User, error) {
 	if user, ok := users[userID]; ok {
-		return user
+		return user, nil
 	}
-
-	return zendesk.User{}
+	return zendesk.User{}, fmt.Errorf("user %d not found in cache", userID)
 }
 
 // getRoleResource creates a new connector resource for a Zendesk role.

--- a/pkg/connector/helpers.go
+++ b/pkg/connector/helpers.go
@@ -7,7 +7,6 @@ import (
 
 	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
 	"github.com/conductorone/baton-sdk/pkg/annotations"
-	ent "github.com/conductorone/baton-sdk/pkg/types/entitlement"
 	rs "github.com/conductorone/baton-sdk/pkg/types/resource"
 	"github.com/nukosuke/go-zendesk/zendesk"
 	"golang.org/x/text/cases"
@@ -27,16 +26,6 @@ func titleCase(s string) string {
 	titleCaser := cases.Title(language.English)
 
 	return titleCaser.String(s)
-}
-
-// Populate entitlement options for zendesk resource.
-func PopulateOptions(displayName, permission, resource string) []ent.EntitlementOption {
-	options := []ent.EntitlementOption{
-		ent.WithDisplayName(fmt.Sprintf("%s Role %s", displayName, permission)),
-		ent.WithDescription(fmt.Sprintf("%s of Zendesk %s %s", permission, displayName, resource)),
-		ent.WithGrantableTo(resourceTypeTeam, resourceTypeGroup),
-	}
-	return options
 }
 
 // getUserRoleResource creates a new connector resource for a Zendesk user.
@@ -94,18 +83,6 @@ func splitFullName(name string) (string, string) {
 	}
 
 	return firstName, lastName
-}
-
-// getUserSupportRoles gets user roles.
-func getUserSupportRoles(users []zendesk.User) map[string]int64 {
-	var supportRoles = make(map[string]int64)
-	for _, user := range users {
-		if !user.Suspended {
-			supportRoles[user.Role] = user.ID
-		}
-	}
-
-	return supportRoles
 }
 
 func getTeamResource(user *zendesk.User, resourceTypeTeam *v2.ResourceType) (*v2.Resource, error) {

--- a/pkg/connector/org.go
+++ b/pkg/connector/org.go
@@ -8,7 +8,6 @@ import (
 
 	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
 	"github.com/conductorone/baton-sdk/pkg/annotations"
-	"github.com/conductorone/baton-sdk/pkg/pagination"
 	ent "github.com/conductorone/baton-sdk/pkg/types/entitlement"
 	"github.com/conductorone/baton-sdk/pkg/types/grant"
 	rs "github.com/conductorone/baton-sdk/pkg/types/resource"
@@ -39,15 +38,15 @@ func (o *orgResourceType) ResourceType(_ context.Context) *v2.ResourceType {
 }
 
 // List returns all the organizations from the database as resource objects.
-func (o *orgResourceType) List(ctx context.Context, parentResourceID *v2.ResourceId, pToken *pagination.Token) ([]*v2.Resource, string, annotations.Annotations, error) {
+func (o *orgResourceType) List(ctx context.Context, parentResourceID *v2.ResourceId, opts rs.SyncOpAttrs) ([]*v2.Resource, *rs.SyncOpResults, error) {
 	var (
 		ret []*v2.Resource
 		err error
 	)
 
-	orgs, nextPageToken, err := o.client.ListOrganizations(ctx, pToken.Token)
+	orgs, nextPageToken, err := o.client.ListOrganizations(ctx, opts.PageToken.Token)
 	if err != nil {
-		return nil, "", nil, fmt.Errorf("zendesk-connector: failed to fetch org: %w", err)
+		return nil, nil, fmt.Errorf("zendesk-connector: failed to fetch org: %w", err)
 	}
 
 	for _, org := range orgs {
@@ -68,16 +67,16 @@ func (o *orgResourceType) List(ctx context.Context, parentResourceID *v2.Resourc
 			),
 		)
 		if err != nil {
-			return nil, "", nil, err
+			return nil, nil, err
 		}
 
 		ret = append(ret, orgResource)
 	}
 
-	return ret, nextPageToken, nil, nil
+	return ret, &rs.SyncOpResults{NextPageToken: nextPageToken}, nil
 }
 
-func (o *orgResourceType) Entitlements(_ context.Context, resource *v2.Resource, _ *pagination.Token) ([]*v2.Entitlement, string, annotations.Annotations, error) {
+func (o *orgResourceType) Entitlements(_ context.Context, resource *v2.Resource, _ rs.SyncOpAttrs) ([]*v2.Entitlement, *rs.SyncOpResults, error) {
 	rv := make([]*v2.Entitlement, 0, len(orgAccessLevels))
 	for _, level := range orgAccessLevels {
 		rv = append(rv, ent.NewPermissionEntitlement(resource, level,
@@ -90,24 +89,24 @@ func (o *orgResourceType) Entitlements(_ context.Context, resource *v2.Resource,
 		))
 	}
 
-	return rv, "", nil, nil
+	return rv, nil, nil
 }
 
-func (o *orgResourceType) Grants(ctx context.Context, resource *v2.Resource, pToken *pagination.Token) ([]*v2.Grant, string, annotations.Annotations, error) {
+func (o *orgResourceType) Grants(ctx context.Context, resource *v2.Resource, opts rs.SyncOpAttrs) ([]*v2.Grant, *rs.SyncOpResults, error) {
 	var (
 		rv  []*v2.Grant
 		err error
 	)
 
-	users, nextPageToken, err := o.client.GetOrganizationUsers(ctx, resource.Id, pToken.Token)
+	users, nextPageToken, err := o.client.GetOrganizationUsers(ctx, resource.Id, opts.PageToken.Token)
 	if err != nil {
-		return nil, "", nil, fmt.Errorf("zendesk-connector: failed to list org members: %w", err)
+		return nil, nil, fmt.Errorf("zendesk-connector: failed to list org members: %w", err)
 	}
 
 	for _, user := range users {
 		ur, err := getUserResource(user, resourceTypeTeam)
 		if err != nil {
-			return nil, "", nil, err
+			return nil, nil, err
 		}
 
 		roleName := strings.ToLower(user.Role)
@@ -124,10 +123,10 @@ func (o *orgResourceType) Grants(ctx context.Context, resource *v2.Resource, pTo
 		}
 	}
 
-	return rv, nextPageToken, nil, nil
+	return rv, &rs.SyncOpResults{NextPageToken: nextPageToken}, nil
 }
 
-func (o *orgResourceType) Grant(ctx context.Context, principal *v2.Resource, entitlement *v2.Entitlement) (annotations.Annotations, error) {
+func (o *orgResourceType) Grant(ctx context.Context, principal *v2.Resource, entitlement *v2.Entitlement) ([]*v2.Grant, annotations.Annotations, error) {
 	l := ctxzap.Extract(ctx)
 	if principal.Id.ResourceType != resourceTypeTeam.Id {
 		l.Warn(
@@ -135,17 +134,17 @@ func (o *orgResourceType) Grant(ctx context.Context, principal *v2.Resource, ent
 			zap.String("principal_type", principal.Id.ResourceType),
 			zap.String("principal_id", principal.Id.Resource),
 		)
-		return nil, fmt.Errorf("zendesk-connector: only users can be granted organization membership")
+		return nil, nil, fmt.Errorf("zendesk-connector: only users can be granted organization membership")
 	}
 
 	userID, err := strconv.ParseInt(principal.Id.Resource, 10, 64)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	organizationID, err := strconv.ParseInt(entitlement.Resource.Id.Resource, 10, 64)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	organizationMembership := zendesk.OrganizationMembership{
@@ -154,7 +153,7 @@ func (o *orgResourceType) Grant(ctx context.Context, principal *v2.Resource, ent
 	}
 	oganizationMembership, err := o.client.CreateOrganizationMembership(ctx, organizationMembership)
 	if err != nil {
-		return nil, fmt.Errorf("zendesk-connector: failed to add user to an organization: %s", err.Error())
+		return nil, nil, fmt.Errorf("zendesk-connector: failed to add user to an organization: %s", err.Error())
 	}
 
 	l.Warn("Membership has been created.",
@@ -164,7 +163,7 @@ func (o *orgResourceType) Grant(ctx context.Context, principal *v2.Resource, ent
 		zap.Time("CreatedAt", oganizationMembership.CreatedAt),
 	)
 
-	return nil, nil
+	return nil, nil, nil
 }
 
 func (o *orgResourceType) Revoke(ctx context.Context, grant *v2.Grant) (annotations.Annotations, error) {

--- a/pkg/connector/org.go
+++ b/pkg/connector/org.go
@@ -156,7 +156,7 @@ func (o *orgResourceType) Grant(ctx context.Context, principal *v2.Resource, ent
 		return nil, nil, fmt.Errorf("baton-zendesk: failed to add user to an organization: %w", err)
 	}
 
-	l.Warn("Membership has been created.",
+	l.Debug("Membership has been created.",
 		zap.Int64("ID", oganizationMembership.ID),
 		zap.Int64("UserID", oganizationMembership.UserID),
 		zap.Int64("OganizationID", oganizationMembership.OrganizationID),
@@ -200,7 +200,7 @@ func (o *orgResourceType) Revoke(ctx context.Context, grant *v2.Grant) (annotati
 		return nil, fmt.Errorf("baton-zendesk: failed to revoke organization: %w", err)
 	}
 
-	l.Warn("Membership has been revoked..",
+	l.Debug("Membership has been revoked.",
 		zap.String("organizationMembershipID", organizationMembershipID),
 	)
 

--- a/pkg/connector/org.go
+++ b/pkg/connector/org.go
@@ -46,7 +46,7 @@ func (o *orgResourceType) List(ctx context.Context, parentResourceID *v2.Resourc
 
 	orgs, nextPageToken, err := o.client.ListOrganizations(ctx, opts.PageToken.Token)
 	if err != nil {
-		return nil, nil, fmt.Errorf("baton-zendesk: failed to fetch org: %w", err)
+		return nil, nil, fmt.Errorf("baton-zendesk: failed to list organizations: %w", err)
 	}
 
 	for _, org := range orgs {

--- a/pkg/connector/org.go
+++ b/pkg/connector/org.go
@@ -46,7 +46,7 @@ func (o *orgResourceType) List(ctx context.Context, parentResourceID *v2.Resourc
 
 	orgs, nextPageToken, err := o.client.ListOrganizations(ctx, opts.PageToken.Token)
 	if err != nil {
-		return nil, nil, fmt.Errorf("zendesk-connector: failed to fetch org: %w", err)
+		return nil, nil, fmt.Errorf("baton-zendesk: failed to fetch org: %w", err)
 	}
 
 	for _, org := range orgs {
@@ -100,7 +100,7 @@ func (o *orgResourceType) Grants(ctx context.Context, resource *v2.Resource, opt
 
 	users, nextPageToken, err := o.client.GetOrganizationUsers(ctx, resource.Id, opts.PageToken.Token)
 	if err != nil {
-		return nil, nil, fmt.Errorf("zendesk-connector: failed to list org members: %w", err)
+		return nil, nil, fmt.Errorf("baton-zendesk: failed to list org members: %w", err)
 	}
 
 	for _, user := range users {
@@ -130,11 +130,11 @@ func (o *orgResourceType) Grant(ctx context.Context, principal *v2.Resource, ent
 	l := ctxzap.Extract(ctx)
 	if principal.Id.ResourceType != resourceTypeTeam.Id {
 		l.Warn(
-			"zendesk-connector: only users can be granted organization membership",
+			"baton-zendesk: only users can be granted organization membership",
 			zap.String("principal_type", principal.Id.ResourceType),
 			zap.String("principal_id", principal.Id.Resource),
 		)
-		return nil, nil, fmt.Errorf("zendesk-connector: only users can be granted organization membership")
+		return nil, nil, fmt.Errorf("baton-zendesk: only users can be granted organization membership")
 	}
 
 	userID, err := strconv.ParseInt(principal.Id.Resource, 10, 64)
@@ -153,7 +153,7 @@ func (o *orgResourceType) Grant(ctx context.Context, principal *v2.Resource, ent
 	}
 	oganizationMembership, err := o.client.CreateOrganizationMembership(ctx, organizationMembership)
 	if err != nil {
-		return nil, nil, fmt.Errorf("zendesk-connector: failed to add user to an organization: %s", err.Error())
+		return nil, nil, fmt.Errorf("baton-zendesk: failed to add user to an organization: %w", err)
 	}
 
 	l.Warn("Membership has been created.",
@@ -174,11 +174,11 @@ func (o *orgResourceType) Revoke(ctx context.Context, grant *v2.Grant) (annotati
 
 	if principal.Id.ResourceType != resourceTypeTeam.Id {
 		l.Warn(
-			"zendesk-connector: only users can have organization membership revoked",
+			"baton-zendesk: only users can have organization membership revoked",
 			zap.String("principal_type", principal.Id.ResourceType),
 			zap.String("principal_id", principal.Id.Resource),
 		)
-		return nil, fmt.Errorf("zendesk-connector: only users can have organization membership revoked")
+		return nil, fmt.Errorf("baton-zendesk: only users can have organization membership revoked")
 	}
 
 	userID, err := strconv.ParseInt(principal.Id.Resource, 10, 64)
@@ -197,7 +197,7 @@ func (o *orgResourceType) Revoke(ctx context.Context, grant *v2.Grant) (annotati
 	}
 	organizationMembershipID, err := o.client.RemoveOrganizationMembershipByID(ctx, organizationMembership)
 	if err != nil {
-		return nil, fmt.Errorf("zendesk-connector: failed to revoke organization: %s", err.Error())
+		return nil, fmt.Errorf("baton-zendesk: failed to revoke organization: %w", err)
 	}
 
 	l.Warn("Membership has been revoked..",

--- a/pkg/connector/role.go
+++ b/pkg/connector/role.go
@@ -122,38 +122,10 @@ func (r *roleResourceType) Grant(ctx context.Context, principal *v2.Resource, en
 }
 
 func (r *roleResourceType) Revoke(ctx context.Context, grant *v2.Grant) (annotations.Annotations, error) {
-	l := ctxzap.Extract(ctx)
-
-	principal := grant.Principal
-	if principal.Id.ResourceType != resourceTypeTeam.Id {
-		l.Warn(
-			"baton-zendesk: only team members can have role membership revoked",
-			zap.String("principal_type", principal.Id.ResourceType),
-			zap.String("principal_id", principal.Id.Resource),
-		)
-		return nil, fmt.Errorf("baton-zendesk: only team members can have role membership revoked")
-	}
-
-	// Revoking admin is not supported via the custom role model.
-	if grant.Entitlement.Slug == zendesk.UserRoleText(zendesk.UserRoleAdmin) {
-		return nil, fmt.Errorf("baton-zendesk: revoking admin role is not supported")
-	}
-
-	userID, err := strconv.ParseInt(principal.Id.Resource, 10, 64)
-	if err != nil {
-		return nil, err
-	}
-
-	// Setting custom_role_id to 0 removes the custom role and reverts the user to the base agent role.
-	updatedUser, err := r.client.UpdateUser(ctx, userID, map[string]any{"user": map[string]any{"custom_role_id": 0}})
-	if err != nil {
-		return nil, fmt.Errorf("baton-zendesk: failed to revoke custom role from user: %w", err)
-	}
-
-	l.Debug("Custom role revoked, user reverted to base agent role.",
-		zap.Int64("userID", updatedUser.ID),
-	)
-
+	// TODO: implement role revoke
+	// - validate principal is resourceTypeTeam
+	// - reject admin role revoke (not supported via custom role model)
+	// - set custom_role_id=0 to revert user to base agent role
 	return nil, nil
 }
 

--- a/pkg/connector/role.go
+++ b/pkg/connector/role.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"strconv"
+	"strings"
 
 	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
 	"github.com/conductorone/baton-sdk/pkg/annotations"
@@ -79,7 +80,7 @@ func (r *roleResourceType) Grants(ctx context.Context, resource *v2.Resource, op
 		if err != nil {
 			return nil, nil, fmt.Errorf("error creating team_member resource for role %s: %w", resource.Id.Resource, err)
 		}
-		rv = append(rv, grant.NewGrant(resource, user.Role, ur.Id))
+		rv = append(rv, grant.NewGrant(resource, strings.ToLower(user.Role), ur.Id))
 	}
 
 	return rv, &rs.SyncOpResults{NextPageToken: nextPageToken}, nil

--- a/pkg/connector/role.go
+++ b/pkg/connector/role.go
@@ -32,7 +32,7 @@ func (r *roleResourceType) List(ctx context.Context, parentId *v2.ResourceId, _ 
 	var rv []*v2.Resource
 	customRole, err := r.client.GetCustomRoles(ctx)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, fmt.Errorf("baton-zendesk: failed to list custom roles: %w", err)
 	}
 	for _, role := range customRole {
 		roleCopy := role
@@ -70,7 +70,7 @@ func (r *roleResourceType) Grants(ctx context.Context, resource *v2.Resource, op
 
 	users, nextPageToken, err := r.client.ListUsersByRole(ctx, roleID, opts.PageToken.Token)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, fmt.Errorf("baton-zendesk: failed to list users by role %d: %w", roleID, err)
 	}
 
 	var rv []*v2.Grant

--- a/pkg/connector/role.go
+++ b/pkg/connector/role.go
@@ -121,6 +121,38 @@ func (r *roleResourceType) Grant(ctx context.Context, principal *v2.Resource, en
 }
 
 func (r *roleResourceType) Revoke(ctx context.Context, grant *v2.Grant) (annotations.Annotations, error) {
+	l := ctxzap.Extract(ctx)
+
+	principal := grant.Principal
+	if principal.Id.ResourceType != resourceTypeTeam.Id {
+		l.Warn(
+			"baton-zendesk: only team members can have role membership revoked",
+			zap.String("principal_type", principal.Id.ResourceType),
+			zap.String("principal_id", principal.Id.Resource),
+		)
+		return nil, fmt.Errorf("baton-zendesk: only team members can have role membership revoked")
+	}
+
+	// Revoking admin is not supported via the custom role model.
+	if grant.Entitlement.Slug == zendesk.UserRoleText(zendesk.UserRoleAdmin) {
+		return nil, fmt.Errorf("baton-zendesk: revoking admin role is not supported")
+	}
+
+	userID, err := strconv.ParseInt(principal.Id.Resource, 10, 64)
+	if err != nil {
+		return nil, err
+	}
+
+	// Setting custom_role_id to 0 removes the custom role and reverts the user to the base agent role.
+	updatedUser, err := r.client.UpdateUser(ctx, userID, map[string]any{"user": map[string]any{"custom_role_id": 0}})
+	if err != nil {
+		return nil, fmt.Errorf("baton-zendesk: failed to revoke custom role from user: %w", err)
+	}
+
+	l.Debug("Custom role revoked, user reverted to base agent role.",
+		zap.Int64("userID", updatedUser.ID),
+	)
+
 	return nil, nil
 }
 

--- a/pkg/connector/role.go
+++ b/pkg/connector/role.go
@@ -63,38 +63,27 @@ func (r *roleResourceType) StaticEntitlements(_ context.Context, _ rs.SyncOpAttr
 }
 
 func (r *roleResourceType) Grants(ctx context.Context, resource *v2.Resource, opts rs.SyncOpAttrs) ([]*v2.Grant, *rs.SyncOpResults, error) {
-	var (
-		err error
-		rv  []*v2.Grant
-	)
-
-	users, err := r.connector.cacheUsers(ctx, opts.Session)
+	roleID, err := strconv.ParseInt(resource.Id.Resource, 10, 64)
 	if err != nil {
 		return nil, nil, err
 	}
 
+	users, nextPageToken, err := r.client.ListUsersByRole(ctx, roleID, opts.PageToken.Token)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var rv []*v2.Grant
 	for _, user := range users {
 		userCopy := user
-
-		resourceId, err := strconv.ParseInt(resource.Id.Resource, 10, 64)
-		if err != nil {
-			return nil, nil, err
-		}
-
-		if user.CustomRoleID != resourceId {
-			continue
-		}
-
 		ur, err := getUserRoleResource(&userCopy, resourceTypeTeam)
 		if err != nil {
 			return nil, nil, fmt.Errorf("error creating team_member resource for role %s: %w", resource.Id.Resource, err)
 		}
-
-		gr := grant.NewGrant(resource, user.Role, ur.Id)
-		rv = append(rv, gr)
+		rv = append(rv, grant.NewGrant(resource, user.Role, ur.Id))
 	}
 
-	return rv, nil, nil
+	return rv, &rs.SyncOpResults{NextPageToken: nextPageToken}, nil
 }
 
 func (r *roleResourceType) Grant(ctx context.Context, principal *v2.Resource, entitlement *v2.Entitlement) ([]*v2.Grant, annotations.Annotations, error) {

--- a/pkg/connector/role.go
+++ b/pkg/connector/role.go
@@ -47,24 +47,18 @@ func (r *roleResourceType) List(ctx context.Context, parentId *v2.ResourceId, _ 
 	return rv, nil, nil
 }
 
-func (r *roleResourceType) Entitlements(ctx context.Context, resource *v2.Resource, opts rs.SyncOpAttrs) ([]*v2.Entitlement, *rs.SyncOpResults, error) {
-	var (
-		err error
-		rv  []*v2.Entitlement
-	)
+func (r *roleResourceType) Entitlements(_ context.Context, _ *v2.Resource, _ rs.SyncOpAttrs) ([]*v2.Entitlement, *rs.SyncOpResults, error) {
+	return nil, nil, nil
+}
 
-	// TODO: luisina - review cache handling
-	users, err := r.connector.cacheUsers(ctx, opts.Session)
-	if err != nil {
-		return nil, nil, err
+func (r *roleResourceType) StaticEntitlements(_ context.Context, _ rs.SyncOpAttrs) ([]*v2.Entitlement, *rs.SyncOpResults, error) {
+	var rv []*v2.Entitlement
+	for _, roleType := range []int{zendesk.UserRoleAgent, zendesk.UserRoleAdmin} {
+		supportRole := zendesk.UserRoleText(roleType)
+		rv = append(rv, ent.NewPermissionEntitlement(nil, supportRole,
+			ent.WithGrantableTo(resourceTypeTeam, resourceTypeGroup),
+		))
 	}
-
-	for supportRole := range getUserSupportRoles(users) {
-		permissionOptions := PopulateOptions(resource.DisplayName, supportRole, resource.Id.Resource)
-		permissionEn := ent.NewPermissionEntitlement(resource, supportRole, permissionOptions...)
-		rv = append(rv, permissionEn)
-	}
-
 	return rv, nil, nil
 }
 

--- a/pkg/connector/role.go
+++ b/pkg/connector/role.go
@@ -19,7 +19,6 @@ import (
 type roleResourceType struct {
 	resourceType *v2.ResourceType
 	client       *client.ZendeskClient
-	connector    *Connector
 }
 
 func (r *roleResourceType) ResourceType(_ context.Context) *v2.ResourceType {
@@ -103,19 +102,6 @@ func (r *roleResourceType) Grant(ctx context.Context, principal *v2.Resource, en
 		return nil, nil, err
 	}
 
-	user, err := r.client.GetUser(ctx, userID)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	if user.Role == zendesk.UserRoleText(zendesk.UserRoleEndUser) {
-		l.Warn("user must be a team member",
-			zap.Int64("user", user.ID),
-			zap.String("user.Role", user.Role),
-		)
-		return nil, nil, fmt.Errorf("user must be a team member")
-	}
-
 	roleID, err := strconv.ParseInt(entitlement.Resource.Id.Resource, 10, 64)
 	if err != nil {
 		return nil, nil, err
@@ -126,7 +112,7 @@ func (r *roleResourceType) Grant(ctx context.Context, principal *v2.Resource, en
 		return nil, nil, fmt.Errorf("baton-zendesk: failed to assign custom role to user: %w", err)
 	}
 
-	l.Info("Custom role assigned to user.",
+	l.Debug("Custom role assigned to user.",
 		zap.Int64("userID", updatedUser.ID),
 		zap.Int64("roleID", roleID),
 	)
@@ -138,10 +124,9 @@ func (r *roleResourceType) Revoke(ctx context.Context, grant *v2.Grant) (annotat
 	return nil, nil
 }
 
-func roleBuilder(c *client.ZendeskClient, connector *Connector) *roleResourceType {
+func roleBuilder(c *client.ZendeskClient) *roleResourceType {
 	return &roleResourceType{
 		resourceType: resourceTypeRole,
 		client:       c,
-		connector:    connector,
 	}
 }

--- a/pkg/connector/role.go
+++ b/pkg/connector/role.go
@@ -108,7 +108,7 @@ func (r *roleResourceType) Grant(ctx context.Context, principal *v2.Resource, en
 		return nil, nil, err
 	}
 
-	if user.Role == "end-user" {
+	if user.Role == zendesk.UserRoleText(zendesk.UserRoleEndUser) {
 		l.Warn("user must be a team member",
 			zap.Int64("user", user.ID),
 			zap.String("user.Role", user.Role),
@@ -121,19 +121,14 @@ func (r *roleResourceType) Grant(ctx context.Context, principal *v2.Resource, en
 		return nil, nil, err
 	}
 
-	roleMembershipOptions := zendesk.CustomRole{
-		Name: fmt.Sprintf("Custom Role %d ", roleID),
-	}
-	membership, err := r.client.CreateCustomRoleMembership(ctx, roleMembershipOptions)
+	updatedUser, err := r.client.UpdateUser(ctx, userID, map[string]any{"user": map[string]any{"custom_role_id": roleID}})
 	if err != nil {
-		return nil, nil, fmt.Errorf("zendesk-connector: failed to add team member to a group: %s", err.Error())
+		return nil, nil, fmt.Errorf("baton-zendesk: failed to assign custom role to user: %w", err)
 	}
 
-	l.Warn("Role Membership has been created.",
-		zap.Int64("ID", membership.ID),
-		zap.String("Name", membership.Name),
-		zap.String("Configuration", fmt.Sprintf("%v", membership.Configuration)),
-		zap.Time("CreatedAt", membership.CreatedAt),
+	l.Info("Custom role assigned to user.",
+		zap.Int64("userID", updatedUser.ID),
+		zap.Int64("roleID", roleID),
 	)
 
 	return nil, nil, nil

--- a/pkg/connector/role.go
+++ b/pkg/connector/role.go
@@ -7,9 +7,9 @@ import (
 
 	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
 	"github.com/conductorone/baton-sdk/pkg/annotations"
-	"github.com/conductorone/baton-sdk/pkg/pagination"
 	ent "github.com/conductorone/baton-sdk/pkg/types/entitlement"
 	"github.com/conductorone/baton-sdk/pkg/types/grant"
+	rs "github.com/conductorone/baton-sdk/pkg/types/resource"
 	"github.com/conductorone/baton-zendesk/pkg/client"
 	"github.com/grpc-ecosystem/go-grpc-middleware/logging/zap/ctxzap"
 	"github.com/nukosuke/go-zendesk/zendesk"
@@ -28,34 +28,35 @@ func (r *roleResourceType) ResourceType(_ context.Context) *v2.ResourceType {
 
 // List returns all the roles from the database as resource objects.
 // Roles include a RoleTrait because they are the 'shape' of a standard group.
-func (r *roleResourceType) List(ctx context.Context, parentId *v2.ResourceId, token *pagination.Token) ([]*v2.Resource, string, annotations.Annotations, error) {
+func (r *roleResourceType) List(ctx context.Context, parentId *v2.ResourceId, _ rs.SyncOpAttrs) ([]*v2.Resource, *rs.SyncOpResults, error) {
 	var rv []*v2.Resource
 	customRole, err := r.client.GetCustomRoles(ctx)
 	if err != nil {
-		return nil, "", nil, err
+		return nil, nil, err
 	}
 	for _, role := range customRole {
 		roleCopy := role
 		rr, err := getRoleResource(&roleCopy, resourceTypeRole, parentId)
 		if err != nil {
-			return nil, "", nil, err
+			return nil, nil, err
 		}
 
 		rv = append(rv, rr)
 	}
 
-	return rv, "", nil, nil
+	return rv, nil, nil
 }
 
-func (r *roleResourceType) Entitlements(ctx context.Context, resource *v2.Resource, token *pagination.Token) ([]*v2.Entitlement, string, annotations.Annotations, error) {
+func (r *roleResourceType) Entitlements(ctx context.Context, resource *v2.Resource, opts rs.SyncOpAttrs) ([]*v2.Entitlement, *rs.SyncOpResults, error) {
 	var (
 		err error
 		rv  []*v2.Entitlement
 	)
 
-	users, err := r.connector.cacheUsers(ctx)
+	// TODO: luisina - review cache handling
+	users, err := r.connector.cacheUsers(ctx, opts.Session)
 	if err != nil {
-		return nil, "", nil, err
+		return nil, nil, err
 	}
 
 	for supportRole := range getUserSupportRoles(users) {
@@ -64,18 +65,18 @@ func (r *roleResourceType) Entitlements(ctx context.Context, resource *v2.Resour
 		rv = append(rv, permissionEn)
 	}
 
-	return rv, "", nil, nil
+	return rv, nil, nil
 }
 
-func (r *roleResourceType) Grants(ctx context.Context, resource *v2.Resource, token *pagination.Token) ([]*v2.Grant, string, annotations.Annotations, error) {
+func (r *roleResourceType) Grants(ctx context.Context, resource *v2.Resource, opts rs.SyncOpAttrs) ([]*v2.Grant, *rs.SyncOpResults, error) {
 	var (
 		err error
 		rv  []*v2.Grant
 	)
 
-	users, err := r.connector.cacheUsers(ctx)
+	users, err := r.connector.cacheUsers(ctx, opts.Session)
 	if err != nil {
-		return nil, "", nil, err
+		return nil, nil, err
 	}
 
 	for _, user := range users {
@@ -83,7 +84,7 @@ func (r *roleResourceType) Grants(ctx context.Context, resource *v2.Resource, to
 
 		resourceId, err := strconv.ParseInt(resource.Id.Resource, 10, 64)
 		if err != nil {
-			return nil, "", nil, err
+			return nil, nil, err
 		}
 
 		if user.CustomRoleID != resourceId {
@@ -92,17 +93,17 @@ func (r *roleResourceType) Grants(ctx context.Context, resource *v2.Resource, to
 
 		ur, err := getUserRoleResource(&userCopy, resourceTypeTeam)
 		if err != nil {
-			return nil, "", nil, fmt.Errorf("error creating team_member resource for role %s: %w", resource.Id.Resource, err)
+			return nil, nil, fmt.Errorf("error creating team_member resource for role %s: %w", resource.Id.Resource, err)
 		}
 
 		gr := grant.NewGrant(resource, user.Role, ur.Id)
 		rv = append(rv, gr)
 	}
 
-	return rv, "", nil, nil
+	return rv, nil, nil
 }
 
-func (r *roleResourceType) Grant(ctx context.Context, principal *v2.Resource, entitlement *v2.Entitlement) (annotations.Annotations, error) {
+func (r *roleResourceType) Grant(ctx context.Context, principal *v2.Resource, entitlement *v2.Entitlement) ([]*v2.Grant, annotations.Annotations, error) {
 	l := ctxzap.Extract(ctx)
 
 	if principal.Id.ResourceType != resourceTypeTeam.Id {
@@ -111,17 +112,17 @@ func (r *roleResourceType) Grant(ctx context.Context, principal *v2.Resource, en
 			zap.String("principal_type", principal.Id.ResourceType),
 			zap.String("principal_id", principal.Id.Resource),
 		)
-		return nil, fmt.Errorf("baton-zendesk: only team members can be granted role membership")
+		return nil, nil, fmt.Errorf("baton-zendesk: only team members can be granted role membership")
 	}
 
 	userID, err := strconv.ParseInt(principal.Id.Resource, 10, 64)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	user, err := r.client.GetUser(ctx, userID)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	if user.Role == "end-user" {
@@ -129,12 +130,12 @@ func (r *roleResourceType) Grant(ctx context.Context, principal *v2.Resource, en
 			zap.Int64("user", user.ID),
 			zap.String("user.Role", user.Role),
 		)
-		return nil, fmt.Errorf("user must be a team member")
+		return nil, nil, fmt.Errorf("user must be a team member")
 	}
 
 	roleID, err := strconv.ParseInt(entitlement.Resource.Id.Resource, 10, 64)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	roleMembershipOptions := zendesk.CustomRole{
@@ -142,7 +143,7 @@ func (r *roleResourceType) Grant(ctx context.Context, principal *v2.Resource, en
 	}
 	membership, err := r.client.CreateCustomRoleMembership(ctx, roleMembershipOptions)
 	if err != nil {
-		return nil, fmt.Errorf("zendesk-connector: failed to add team member to a group: %s", err.Error())
+		return nil, nil, fmt.Errorf("zendesk-connector: failed to add team member to a group: %s", err.Error())
 	}
 
 	l.Warn("Role Membership has been created.",
@@ -152,7 +153,7 @@ func (r *roleResourceType) Grant(ctx context.Context, principal *v2.Resource, en
 		zap.Time("CreatedAt", membership.CreatedAt),
 	)
 
-	return nil, nil
+	return nil, nil, nil
 }
 
 func (r *roleResourceType) Revoke(ctx context.Context, grant *v2.Grant) (annotations.Annotations, error) {

--- a/pkg/connector/role.go
+++ b/pkg/connector/role.go
@@ -122,11 +122,11 @@ func (r *roleResourceType) Grant(ctx context.Context, principal *v2.Resource, en
 }
 
 func (r *roleResourceType) Revoke(ctx context.Context, grant *v2.Grant) (annotations.Annotations, error) {
-	// TODO: implement role revoke
+	// TODO(CXH-1284): implement role revoke
 	// - validate principal is resourceTypeTeam
 	// - reject admin role revoke (not supported via custom role model)
 	// - set custom_role_id=0 to revert user to base agent role
-	return nil, nil
+	return nil, fmt.Errorf("baton-zendesk: role revoke not yet implemented")
 }
 
 func roleBuilder(c *client.ZendeskClient) *roleResourceType {

--- a/pkg/connector/team_member.go
+++ b/pkg/connector/team_member.go
@@ -28,7 +28,7 @@ func (t *teamMemberResourceType) ResourceType(ctx context.Context) *v2.ResourceT
 func (t *teamMemberResourceType) List(ctx context.Context, parentResourceID *v2.ResourceId, opts rs.SyncOpAttrs) ([]*v2.Resource, *rs.SyncOpResults, error) {
 	users, nextPageToken, err := t.client.ListUsers(ctx, opts.PageToken.Token)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, fmt.Errorf("baton-zendesk: failed to list users: %w", err)
 	}
 
 	if err := populateCache(ctx, opts.Session, users); err != nil {

--- a/pkg/connector/team_member.go
+++ b/pkg/connector/team_member.go
@@ -27,9 +27,12 @@ func (t *teamMemberResourceType) ResourceType(ctx context.Context) *v2.ResourceT
 
 // Team Members are users with the role of "agent" or "admin". users with the role of "end-user" are not team members, but rather customers.
 func (t *teamMemberResourceType) List(ctx context.Context, parentResourceID *v2.ResourceId, opts rs.SyncOpAttrs) ([]*v2.Resource, *rs.SyncOpResults, error) {
-	// TODO: luisina - review cache handling
-	users, err := t.connector.cacheUsers(ctx, opts.Session)
+	users, nextPageToken, err := t.client.ListUsers(ctx, opts.PageToken.Token)
 	if err != nil {
+		return nil, nil, err
+	}
+
+	if err := t.connector.populateCache(ctx, opts.Session, users); err != nil {
 		return nil, nil, err
 	}
 
@@ -40,11 +43,10 @@ func (t *teamMemberResourceType) List(ctx context.Context, parentResourceID *v2.
 		if err != nil {
 			return nil, nil, err
 		}
-
 		rv = append(rv, userResource)
 	}
 
-	return rv, nil, nil
+	return rv, &rs.SyncOpResults{NextPageToken: nextPageToken}, nil
 }
 
 func (t *teamMemberResourceType) Entitlements(_ context.Context, _ *v2.Resource, _ rs.SyncOpAttrs) ([]*v2.Entitlement, *rs.SyncOpResults, error) {

--- a/pkg/connector/team_member.go
+++ b/pkg/connector/team_member.go
@@ -10,7 +10,7 @@ import (
 	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
 	"github.com/conductorone/baton-sdk/pkg/annotations"
 	"github.com/conductorone/baton-sdk/pkg/connectorbuilder"
-	"github.com/conductorone/baton-sdk/pkg/pagination"
+	rs "github.com/conductorone/baton-sdk/pkg/types/resource"
 	"github.com/conductorone/baton-zendesk/pkg/client"
 	"github.com/nukosuke/go-zendesk/zendesk"
 )
@@ -26,10 +26,11 @@ func (t *teamMemberResourceType) ResourceType(ctx context.Context) *v2.ResourceT
 }
 
 // Team Members are users with the role of "agent" or "admin". users with the role of "end-user" are not team members, but rather customers.
-func (t *teamMemberResourceType) List(ctx context.Context, parentResourceID *v2.ResourceId, pt *pagination.Token) ([]*v2.Resource, string, annotations.Annotations, error) {
-	users, err := t.connector.cacheUsers(ctx)
+func (t *teamMemberResourceType) List(ctx context.Context, parentResourceID *v2.ResourceId, opts rs.SyncOpAttrs) ([]*v2.Resource, *rs.SyncOpResults, error) {
+	// TODO: luisina - review cache handling
+	users, err := t.connector.cacheUsers(ctx, opts.Session)
 	if err != nil {
-		return nil, "", nil, err
+		return nil, nil, err
 	}
 
 	var rv []*v2.Resource
@@ -37,21 +38,21 @@ func (t *teamMemberResourceType) List(ctx context.Context, parentResourceID *v2.
 		userCopy := user
 		userResource, err := getTeamResource(&userCopy, t.resourceType)
 		if err != nil {
-			return nil, "", nil, err
+			return nil, nil, err
 		}
 
 		rv = append(rv, userResource)
 	}
 
-	return rv, "", nil, nil
+	return rv, nil, nil
 }
 
-func (t *teamMemberResourceType) Entitlements(ctx context.Context, resource *v2.Resource, pt *pagination.Token) ([]*v2.Entitlement, string, annotations.Annotations, error) {
-	return nil, "", nil, nil
+func (t *teamMemberResourceType) Entitlements(_ context.Context, _ *v2.Resource, _ rs.SyncOpAttrs) ([]*v2.Entitlement, *rs.SyncOpResults, error) {
+	return nil, nil, nil
 }
 
-func (t *teamMemberResourceType) Grants(ctx context.Context, resource *v2.Resource, pt *pagination.Token) ([]*v2.Grant, string, annotations.Annotations, error) {
-	return nil, "", nil, nil
+func (t *teamMemberResourceType) Grants(_ context.Context, _ *v2.Resource, _ rs.SyncOpAttrs) ([]*v2.Grant, *rs.SyncOpResults, error) {
+	return nil, nil, nil
 }
 
 func (t *teamMemberResourceType) CreateAccountCapabilityDetails(ctx context.Context) (*v2.CredentialDetailsAccountProvisioning, annotations.Annotations, error) {

--- a/pkg/connector/team_member.go
+++ b/pkg/connector/team_member.go
@@ -18,7 +18,6 @@ import (
 type teamMemberResourceType struct {
 	resourceType *v2.ResourceType
 	client       *client.ZendeskClient
-	connector    *Connector
 }
 
 func (t *teamMemberResourceType) ResourceType(ctx context.Context) *v2.ResourceType {
@@ -32,7 +31,7 @@ func (t *teamMemberResourceType) List(ctx context.Context, parentResourceID *v2.
 		return nil, nil, err
 	}
 
-	if err := t.connector.populateCache(ctx, opts.Session, users); err != nil {
+	if err := populateCache(ctx, opts.Session, users); err != nil {
 		return nil, nil, err
 	}
 
@@ -140,10 +139,9 @@ func (t *teamMemberResourceType) Delete(ctx context.Context, resourceId *v2.Reso
 	return nil, nil
 }
 
-func teamMemberBuilder(zendeskClient *client.ZendeskClient, connector *Connector) *teamMemberResourceType {
+func teamMemberBuilder(zendeskClient *client.ZendeskClient) *teamMemberResourceType {
 	return &teamMemberResourceType{
 		resourceType: resourceTypeTeam,
 		client:       zendeskClient,
-		connector:    connector,
 	}
 }


### PR DESCRIPTION
## Summary

- Migrated from deprecated `DefineConfiguration` to `RunConnector` with `WithSessionStoreEnabled()` to support the containerized connector model
- Replaced in-memory TTL user cache with session-store-backed cache (`populateCache` / `getCachedUsersByIDs`), populated incrementally per page during `team_member.List` and consumed in `group.Grants`
- Migrated all resource syncers to SDK v2 interfaces (`ResourceSyncerV2`, `SyncOpAttrs`, `SyncOpResults`)
- Replaced role `Entitlements` (cache-based) with `StaticEntitlements` using Zendesk constants (`agent`, `admin`) — no per-resource cache needed
- Replaced role `Grants` cache+filter with direct `ListUsersByRole` using Zendesk's `PermissionSet` API filter
- **Bug fix:** `role.Grant` was calling `POST /custom_roles` (creating a new role) instead of `PUT /users/:id` with `custom_role_id` — now correctly assigns the custom role to the user
- Removed invalid reverse grants in `group.Grants` that were causing MISSING ENTITLEMENT errors
- Normalized all error prefixes to `baton-zendesk:`, replaced `%s + err.Error()` with `%w`, replaced success `Warn` logs with `Debug`

## Sync equivalence

Sync output was validated by comparing `.c1z` snapshots from `v0.0.8` and this branch — resources and grants are equivalent.

## QA focus

Sync behavior is consistent between versions.
New changes:
   | Action | v0.0.8 | This branch |
   |---|---|---|
   | Grant custom role | `POST /custom_roles` (created a new role — broken) | `PUT /users/:id` with `custom_role_id` (correct) |

   **Test cases needed:**
   1. Grant a custom role to a user — verify the role is updated in Zendesk.

Follow ups handled as part of: https://linear.app/ductone/issue/CXH-1284/implement-role-revoke-and-grant-idempotency-for-baton-zendesk
