### PR TITLE
docs: fix connector doc regressions

### DIFF
--- a/docs/connector.mdx
+++ b/docs/connector.mdx
@@ -60,7 +60,7 @@ Make a note of your subdomain.
 Log in to your Zendesk account at `yoursubdomain.zendesk.com`, then click the gear icon (⚙️) in the left sidebar and click **Go to Admin Center**.
 </Step>
 <Step>
-Navigate to **Apps and integrations** → **APIs** → **API configuration**.
+Navigate to **Apps and integrations** > **APIs** > **API configuration**.
 </Step>
 <Step>
 Make sure both **Token Access** and **Password Access** are toggled on.
@@ -70,7 +70,7 @@ Password Access is required to list group memberships. Without it, the connector
 </Note>
 </Step>
 <Step>
-Navigate to **Apps and integrations** → **APIs** → **API tokens** and click **Add API token**.
+Navigate to **Apps and integrations** > **APIs** > **API tokens** and click **Add API token**.
 </Step>
 <Step>
 Optionally add a description, then copy the token immediately — it won't be shown again.
@@ -80,7 +80,7 @@ Click **Save**.
 </Step>
 </Steps>
 
-**That's it!** Next, move on to the connector configuration instructions.
+**Done.** Next, move on to the connector configuration instructions.
 
 ## Configure the Zendesk connector
 
@@ -143,7 +143,7 @@ The connector's label changes to **Syncing**, followed by **Connected**. You can
 </Step>
 </Steps>
 
-**That's it!** Your Zendesk connector is now pulling access data into C1.
+**Done.** Your Zendesk connector is now pulling access data into C1.
 </Tab>
 <Tab title="Self-hosted">
 
@@ -262,7 +262,7 @@ Check that the connector data uploaded correctly. In C1, click **Apps**. On the 
 </Step>
 </Steps>
 
-**That's it!** Your Zendesk connector is now pulling access data into C1.
+**Done.** Your Zendesk connector is now pulling access data into C1.
 
 </Tab>
 </Tabs>


### PR DESCRIPTION
## Summary

This PR corrects issues in the connector docs that were caught during a sync to the ConductorOne docs site. Specific fixes:

- Restore `**Done.**` closing phrase (sync bot replaced with `**That's it!**`, 3 instances)
- Restore `>` navigation arrow style (sync bot changed to `→`; `>` is house style)

These corrections prevent the sync bot from reintroducing regressions on future runs.