### PR TITLE
fix(team_member): fix CBP cursor truncation and infinite loop for >100 members (CXH-1737)

### DIFF
--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -14,9 +14,6 @@ import (
 	"github.com/nukosuke/go-zendesk/zendesk"
 )
 
-const teamMembersRoleAdmin = "admin"
-const teamMembersRoleAgent = "agent"
-
 // cbpPageSize must be set on every CBP request — Zendesk treats requests
 // without page[size] as offset pagination on endpoints that support both,
 // which leaves meta.has_more/after_cursor empty and stops sync after page 1.
@@ -60,11 +57,13 @@ func New(ctx context.Context, httpClient *http.Client, subdomain string, email s
 	return zc, nil
 }
 
-// ListUsers returns all ZendeskClient users.
-func (z *ZendeskClient) ListUsers(ctx context.Context, pageToken string) ([]zendesk.User, string, error) {
+// ListUsers returns users with the given role using cursor-based pagination.
+// role[] array notation breaks Zendesk's cursor advancement; callers must use
+// the singular role value and manage multi-role passes themselves.
+func (z *ZendeskClient) ListUsers(ctx context.Context, role, pageToken string) ([]zendesk.User, string, error) {
 	users, meta, err := z.client.GetUsersCBP(ctx, &zendesk.CBPOptions{
 		CursorPagination: zendesk.CursorPagination{PageSize: cbpPageSize, PageAfter: pageToken},
-		CommonOptions:    zendesk.CommonOptions{Roles: []string{teamMembersRoleAdmin, teamMembersRoleAgent}},
+		CommonOptions:    zendesk.CommonOptions{Role: role},
 	})
 	if err != nil {
 		return nil, "", wrapZendeskError(err)
@@ -151,15 +150,15 @@ func (z *ZendeskClient) GetOrgName(ctx context.Context, orgID *v2.ResourceId) (s
 	return org.Name, nil
 }
 
-// GetOrganizationUsers fetch organization users list.
-func (z *ZendeskClient) GetOrganizationUsers(ctx context.Context, orgID *v2.ResourceId, pageToken string) ([]zendesk.User, string, error) {
+// GetOrganizationUsers returns org users with the given role using cursor-based pagination.
+func (z *ZendeskClient) GetOrganizationUsers(ctx context.Context, orgID *v2.ResourceId, role, pageToken string) ([]zendesk.User, string, error) {
 	oID, err := strconv.ParseInt(orgID.Resource, 10, 64)
 	if err != nil {
 		return nil, "", err
 	}
 	users, meta, err := z.client.GetOrganizationUsersCBP(ctx, &zendesk.CBPOptions{
 		CursorPagination: zendesk.CursorPagination{PageSize: cbpPageSize, PageAfter: pageToken},
-		CommonOptions:    zendesk.CommonOptions{Id: oID, Roles: []string{teamMembersRoleAdmin, teamMembersRoleAgent}},
+		CommonOptions:    zendesk.CommonOptions{Id: oID, Role: role},
 	})
 	if err != nil {
 		return nil, "", wrapZendeskError(err)

--- a/pkg/connector/org.go
+++ b/pkg/connector/org.go
@@ -9,6 +9,7 @@ import (
 	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
 	"github.com/conductorone/baton-sdk/pkg/annotations"
 	ent "github.com/conductorone/baton-sdk/pkg/types/entitlement"
+	"github.com/conductorone/baton-sdk/pkg/pagination"
 	"github.com/conductorone/baton-sdk/pkg/types/grant"
 	rs "github.com/conductorone/baton-sdk/pkg/types/resource"
 	"github.com/conductorone/baton-zendesk/pkg/client"
@@ -93,16 +94,21 @@ func (o *orgResourceType) Entitlements(_ context.Context, resource *v2.Resource,
 }
 
 func (o *orgResourceType) Grants(ctx context.Context, resource *v2.Resource, opts rs.SyncOpAttrs) ([]*v2.Grant, *rs.SyncOpResults, error) {
-	var (
-		rv  []*v2.Grant
-		err error
-	)
+	bag := &pagination.Bag{}
+	if err := bag.Unmarshal(opts.PageToken.Token); err != nil {
+		return nil, nil, err
+	}
+	if bag.Current() == nil {
+		bag.Push(pagination.PageState{ResourceTypeID: orgRoleAdmin})
+		bag.Push(pagination.PageState{ResourceTypeID: orgRoleAgent})
+	}
 
-	users, nextPageToken, err := o.client.GetOrganizationUsers(ctx, resource.Id, opts.PageToken.Token)
+	users, nextCursor, err := o.client.GetOrganizationUsers(ctx, resource.Id, bag.ResourceTypeID(), bag.PageToken())
 	if err != nil {
 		return nil, nil, fmt.Errorf("baton-zendesk: failed to list org members: %w", err)
 	}
 
+	var rv []*v2.Grant
 	for _, user := range users {
 		ur, err := getUserResource(user, resourceTypeTeam)
 		if err != nil {
@@ -123,7 +129,15 @@ func (o *orgResourceType) Grants(ctx context.Context, resource *v2.Resource, opt
 		}
 	}
 
-	return rv, &rs.SyncOpResults{NextPageToken: nextPageToken}, nil
+	if err := bag.Next(nextCursor); err != nil {
+		return nil, nil, err
+	}
+	nextPage, err := bag.Marshal()
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return rv, &rs.SyncOpResults{NextPageToken: nextPage}, nil
 }
 
 func (o *orgResourceType) Grant(ctx context.Context, principal *v2.Resource, entitlement *v2.Entitlement) ([]*v2.Grant, annotations.Annotations, error) {

--- a/pkg/connector/team_member.go
+++ b/pkg/connector/team_member.go
@@ -10,9 +10,15 @@ import (
 	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
 	"github.com/conductorone/baton-sdk/pkg/annotations"
 	"github.com/conductorone/baton-sdk/pkg/connectorbuilder"
+	"github.com/conductorone/baton-sdk/pkg/pagination"
 	rs "github.com/conductorone/baton-sdk/pkg/types/resource"
 	"github.com/conductorone/baton-zendesk/pkg/client"
 	"github.com/nukosuke/go-zendesk/zendesk"
+)
+
+const (
+	teamRoleAgent = "agent"
+	teamRoleAdmin = "admin"
 )
 
 type teamMemberResourceType struct {
@@ -26,7 +32,16 @@ func (t *teamMemberResourceType) ResourceType(ctx context.Context) *v2.ResourceT
 
 // Team Members are users with the role of "agent" or "admin". users with the role of "end-user" are not team members, but rather customers.
 func (t *teamMemberResourceType) List(ctx context.Context, parentResourceID *v2.ResourceId, opts rs.SyncOpAttrs) ([]*v2.Resource, *rs.SyncOpResults, error) {
-	users, nextPageToken, err := t.client.ListUsers(ctx, opts.PageToken.Token)
+	bag := &pagination.Bag{}
+	if err := bag.Unmarshal(opts.PageToken.Token); err != nil {
+		return nil, nil, err
+	}
+	if bag.Current() == nil {
+		bag.Push(pagination.PageState{ResourceTypeID: teamRoleAdmin})
+		bag.Push(pagination.PageState{ResourceTypeID: teamRoleAgent})
+	}
+
+	users, nextCursor, err := t.client.ListUsers(ctx, bag.ResourceTypeID(), bag.PageToken())
 	if err != nil {
 		return nil, nil, fmt.Errorf("baton-zendesk: failed to list users: %w", err)
 	}
@@ -45,7 +60,15 @@ func (t *teamMemberResourceType) List(ctx context.Context, parentResourceID *v2.
 		rv = append(rv, userResource)
 	}
 
-	return rv, &rs.SyncOpResults{NextPageToken: nextPageToken}, nil
+	if err := bag.Next(nextCursor); err != nil {
+		return nil, nil, err
+	}
+	nextPage, err := bag.Marshal()
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return rv, &rs.SyncOpResults{NextPageToken: nextPage}, nil
 }
 
 func (t *teamMemberResourceType) Entitlements(_ context.Context, _ *v2.Resource, _ rs.SyncOpAttrs) ([]*v2.Entitlement, *rs.SyncOpResults, error) {


### PR DESCRIPTION
## Summary

- Zendesk's CBP endpoint does not advance the cursor when `role[]=admin&role[]=agent` (array notation) is combined with `page[after]`, causing truncation to 100 on mid-size tenants and an infinite re-fetch loop on large tenants
- Switch `ListUsers` and `GetOrganizationUsers` to accept a single `role` param, and move phase management to the connector layer using `pagination.Bag`
- `team_member.List` and `org.Grants` each initialize a two-state bag (agent → admin) and dispatch to the simplified client functions

## Root cause

`role[]` array notation is incompatible with Zendesk's cursor-based pagination. Adding `page[size]` (fixed in v0.1.1 / cb41c97) was necessary but not sufficient — the cursor itself does not advance when `role[]` is present. The fix uses the singular `role=` parameter with two sequential CBP passes managed by a `pagination.Bag`.

## Test plan

- [ ] Build passes (`go build ./...`)
- [ ] Sync against a small tenant (<100 team members) — member count unchanged, no regression
- [ ] Sync against a mid-size tenant (>100 team members) — all members returned, not truncated to 100
- [ ] Sync against a large tenant — sync terminates, no infinite loop
- [ ] Org grants correct on all tenant sizes

Fixes [CXH-1737](https://linear.app/ductone/issue/CXH-1737)

🤖 Generated with [Claude Code](https://claude.com/claude-code)