### PR TITLE
[CXH-1734] fix: resolve correct group/org membership on revoke

### DIFF
--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -37,10 +37,10 @@ const (
 	pathGroupMemberships = "/groups/%d/memberships.json" // GET (list by group)
 
 	// https://developer.zendesk.com/api-reference/ticketing/groups/group_memberships/#list-memberships
-	pathUserGroupMemberships = "/users/%d/group_memberships.json?page=%d&per_page=%d"
+	pathUserGroupMemberships = "/users/%d/group_memberships.json"
 
 	// https://developer.zendesk.com/api-reference/ticketing/organizations/organization_memberships/#list-memberships
-	pathUserOrganizationMemberships = "/users/%d/organization_memberships.json?page=%d&per_page=%d"
+	pathUserOrganizationMemberships = "/users/%d/organization_memberships.json"
 )
 
 // offsetPageSize is the per_page value for offset-paginated lookups.
@@ -279,7 +279,11 @@ func (z *ZendeskClient) GetGroupMembershipByGroup(ctx context.Context, groupMemb
 			NextPage         *string                   `json:"next_page"`
 		}
 
-		body, err := z.client.Get(ctx, fmt.Sprintf(pathUserGroupMemberships, groupMembership.UserID, page, offsetPageSize))
+		query := url.Values{}
+		query.Set("page", strconv.Itoa(page))
+		query.Set("per_page", strconv.Itoa(offsetPageSize))
+		path := fmt.Sprintf(pathUserGroupMemberships, groupMembership.UserID)
+		body, err := z.client.Get(ctx, path+"?"+query.Encode())
 		if err != nil {
 			return "", wrapZendeskError(err)
 		}
@@ -312,7 +316,11 @@ func (z *ZendeskClient) GetOrganizationMembershipByUser(ctx context.Context, org
 			NextPage                *string                          `json:"next_page"`
 		}
 
-		body, err := z.client.Get(ctx, fmt.Sprintf(pathUserOrganizationMemberships, organizationMembership.UserID, page, offsetPageSize))
+		query := url.Values{}
+		query.Set("page", strconv.Itoa(page))
+		query.Set("per_page", strconv.Itoa(offsetPageSize))
+		path := fmt.Sprintf(pathUserOrganizationMemberships, organizationMembership.UserID)
+		body, err := z.client.Get(ctx, path+"?"+query.Encode())
 		if err != nil {
 			return "", wrapZendeskError(err)
 		}

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"net/url"
 	"strconv"
 	"strings"
 
@@ -31,7 +32,19 @@ const (
 	// https://developer.zendesk.com/api-reference/ticketing/users/users/#permanently-delete-user
 	// Permissions: Admins or agents with access to all tickets.
 	pathDeletedUser = "/deleted_users/%d.json"
+
+	// https://developer.zendesk.com/api-reference/ticketing/groups/group_memberships/#list-memberships-by-group-id
+	pathGroupMemberships = "/groups/%d/memberships.json" // GET (list by group)
+
+	// https://developer.zendesk.com/api-reference/ticketing/groups/group_memberships/#list-memberships
+	pathUserGroupMemberships = "/users/%d/group_memberships.json?page=%d&per_page=%d"
+
+	// https://developer.zendesk.com/api-reference/ticketing/organizations/organization_memberships/#list-memberships
+	pathUserOrganizationMemberships = "/users/%d/organization_memberships.json?page=%d&per_page=%d"
 )
+
+// offsetPageSize is the per_page value for offset-paginated lookups.
+const offsetPageSize = 100
 
 type ZendeskClient struct {
 	client *zendesk.Client
@@ -106,16 +119,31 @@ func (z *ZendeskClient) ListOrganizations(ctx context.Context, pageToken string)
 	return orgs, getNextPageToken(meta), nil
 }
 
-// GetGroupMemberships get the memberships of the specified group.
+// GetGroupMemberships lists memberships for a single group.
+//
+// Zendesk API docs: https://developer.zendesk.com/api-reference/ticketing/groups/group_memberships/#list-memberships-by-group-id
 func (z *ZendeskClient) GetGroupMemberships(ctx context.Context, groupId int64, pageToken string) ([]zendesk.GroupMembership, string, error) {
-	memberships, meta, err := z.client.GetGroupMembershipsCBP(ctx, &zendesk.CBPOptions{
-		CursorPagination: zendesk.CursorPagination{PageSize: cbpPageSize, PageAfter: pageToken},
-		CommonOptions:    zendesk.CommonOptions{GroupID: groupId},
-	})
+	query := url.Values{}
+	query.Set("page[size]", strconv.Itoa(cbpPageSize))
+	if pageToken != "" {
+		query.Set("page[after]", pageToken)
+	}
+
+	path := fmt.Sprintf(pathGroupMemberships, groupId)
+	body, err := z.client.Get(ctx, path+"?"+query.Encode())
 	if err != nil {
 		return nil, "", wrapZendeskError(err)
 	}
-	return memberships, getNextPageToken(meta), nil
+
+	var result struct {
+		GroupMemberships []zendesk.GroupMembership `json:"group_memberships"`
+		Meta             zendesk.CursorPaginationMeta `json:"meta"`
+	}
+	if err := json.Unmarshal(body, &result); err != nil {
+		return nil, "", err
+	}
+
+	return result.GroupMemberships, getNextPageToken(result.Meta), nil
 }
 
 // GetUser get an existing user.
@@ -237,49 +265,78 @@ func (z *ZendeskClient) CreateGroupMembership(ctx context.Context, groupMembersh
 	return result.GroupMemberships, nil
 }
 
-// GetGroupMembershipByGroup gets an existing group membership.
-func (z *ZendeskClient) GetGroupMembershipByGroup(ctx context.Context, groupMemberships zendesk.GroupMembership) (string, zendesk.Page, error) {
-	groups, nextPage, err := z.client.GetGroupMemberships(ctx, &zendesk.GroupMembershipListOptions{
-		UserID:  groupMemberships.UserID,
-		GroupID: groupMemberships.GroupID,
-	})
-	if err != nil {
-		return "", zendesk.Page{}, wrapZendeskError(err)
-	}
+// GetGroupMembershipByGroup gets the ID of the user's membership in the given group,
+// or "" if the user is not a member of that group.
+//
+// It lists the user's memberships via /users/{user_id}/group_memberships and matches
+// the group ID client-side. The flat /group_memberships.json endpoint ignores
+// group_id when user_id is also set, so filtering there can return a membership
+// in a different group and a revoke would delete the wrong one (CXH-1734).
+func (z *ZendeskClient) GetGroupMembershipByGroup(ctx context.Context, groupMembership zendesk.GroupMembership) (string, error) {
+	for page := 1; ; page++ {
+		var result struct {
+			GroupMemberships []zendesk.GroupMembership `json:"group_memberships"`
+			NextPage         *string                   `json:"next_page"`
+		}
 
-	for _, group := range groups {
-		if groupMemberships.UserID == group.UserID {
-			return fmt.Sprintf("%d", group.ID), nextPage, nil
+		body, err := z.client.Get(ctx, fmt.Sprintf(pathUserGroupMemberships, groupMembership.UserID, page, offsetPageSize))
+		if err != nil {
+			return "", wrapZendeskError(err)
+		}
+		if err := json.Unmarshal(body, &result); err != nil {
+			return "", err
+		}
+
+		for _, membership := range result.GroupMemberships {
+			if membership.GroupID == groupMembership.GroupID {
+				return fmt.Sprintf("%d", membership.ID), nil
+			}
+		}
+
+		if result.NextPage == nil {
+			return "", nil
 		}
 	}
-
-	return "", zendesk.Page{}, nil
 }
 
-// GetOrganizationMembershipByUser gets an existing organization membership.
-func (z *ZendeskClient) GetOrganizationMembershipByUser(ctx context.Context, organizationMemberships zendesk.OrganizationMembershipListOptions) (string, zendesk.Page, error) {
-	organizations, nextPage, err := z.client.GetOrganizationMemberships(ctx, &zendesk.OrganizationMembershipListOptions{
-		UserID:         organizationMemberships.UserID,
-		OrganizationID: organizationMemberships.OrganizationID,
-	})
-	if err != nil {
-		return "", zendesk.Page{}, wrapZendeskError(err)
-	}
+// GetOrganizationMembershipByUser gets the ID of the user's membership in the given
+// organization, or "" if the user is not a member of that organization.
+//
+// It lists the user's memberships via /users/{user_id}/organization_memberships and
+// matches the organization ID client-side, for the same reason as
+// GetGroupMembershipByGroup: the flat endpoint ignores filter query params.
+func (z *ZendeskClient) GetOrganizationMembershipByUser(ctx context.Context, organizationMembership zendesk.OrganizationMembershipListOptions) (string, error) {
+	for page := 1; ; page++ {
+		var result struct {
+			OrganizationMemberships []zendesk.OrganizationMembership `json:"organization_memberships"`
+			NextPage                *string                          `json:"next_page"`
+		}
 
-	for _, organization := range organizations {
-		if organizationMemberships.UserID == organization.UserID {
-			return fmt.Sprintf("%d", organization.ID), nextPage, nil
+		body, err := z.client.Get(ctx, fmt.Sprintf(pathUserOrganizationMemberships, organizationMembership.UserID, page, offsetPageSize))
+		if err != nil {
+			return "", wrapZendeskError(err)
+		}
+		if err := json.Unmarshal(body, &result); err != nil {
+			return "", err
+		}
+
+		for _, membership := range result.OrganizationMemberships {
+			if membership.OrganizationID == organizationMembership.OrganizationID {
+				return fmt.Sprintf("%d", membership.ID), nil
+			}
+		}
+
+		if result.NextPage == nil {
+			return "", nil
 		}
 	}
-
-	return "", zendesk.Page{}, nil
 }
 
 // RemoveGroupMembershipByID removes a user from a group, given a specified
 //
 // Zendesk API docs: https://developer.zendesk.com/api-reference/ticketing/groups/group_memberships/#list-memberships
 func (z *ZendeskClient) RemoveGroupMembershipByID(ctx context.Context, groupMemberships zendesk.GroupMembership) (string, error) {
-	groupMembershipID, _, err := z.GetGroupMembershipByGroup(ctx, groupMemberships)
+	groupMembershipID, err := z.GetGroupMembershipByGroup(ctx, groupMemberships)
 	if err != nil {
 		return "", err
 	}
@@ -299,7 +356,7 @@ func (z *ZendeskClient) RemoveGroupMembershipByID(ctx context.Context, groupMemb
 //
 // Zendesk API docs: https://developer.zendesk.com/api-reference/ticketing/organizations/organization_memberships/#list-memberships
 func (z *ZendeskClient) RemoveOrganizationMembershipByID(ctx context.Context, organizationMemberships zendesk.OrganizationMembershipListOptions) (string, error) {
-	organizationMembershipID, _, err := z.GetOrganizationMembershipByUser(ctx, organizationMemberships)
+	organizationMembershipID, err := z.GetOrganizationMembershipByUser(ctx, organizationMemberships)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -43,9 +43,6 @@ const (
 	pathUserOrganizationMemberships = "/users/%d/organization_memberships.json"
 )
 
-// offsetPageSize is the per_page value for offset-paginated lookups.
-const offsetPageSize = 100
-
 type ZendeskClient struct {
 	client *zendesk.Client
 }
@@ -136,7 +133,7 @@ func (z *ZendeskClient) GetGroupMemberships(ctx context.Context, groupId int64, 
 	}
 
 	var result struct {
-		GroupMemberships []zendesk.GroupMembership `json:"group_memberships"`
+		GroupMemberships []zendesk.GroupMembership    `json:"group_memberships"`
 		Meta             zendesk.CursorPaginationMeta `json:"meta"`
 	}
 	if err := json.Unmarshal(body, &result); err != nil {
@@ -273,15 +270,17 @@ func (z *ZendeskClient) CreateGroupMembership(ctx context.Context, groupMembersh
 // group_id when user_id is also set, so filtering there can return a membership
 // in a different group and a revoke would delete the wrong one (CXH-1734).
 func (z *ZendeskClient) GetGroupMembershipByGroup(ctx context.Context, groupMembership zendesk.GroupMembership) (string, error) {
-	for page := 1; ; page++ {
+	for cursor := ""; ; {
 		var result struct {
-			GroupMemberships []zendesk.GroupMembership `json:"group_memberships"`
-			NextPage         *string                   `json:"next_page"`
+			GroupMemberships []zendesk.GroupMembership    `json:"group_memberships"`
+			Meta             zendesk.CursorPaginationMeta `json:"meta"`
 		}
 
 		query := url.Values{}
-		query.Set("page", strconv.Itoa(page))
-		query.Set("per_page", strconv.Itoa(offsetPageSize))
+		query.Set("page[size]", strconv.Itoa(cbpPageSize))
+		if cursor != "" {
+			query.Set("page[after]", cursor)
+		}
 		path := fmt.Sprintf(pathUserGroupMemberships, groupMembership.UserID)
 		body, err := z.client.Get(ctx, path+"?"+query.Encode())
 		if err != nil {
@@ -297,7 +296,8 @@ func (z *ZendeskClient) GetGroupMembershipByGroup(ctx context.Context, groupMemb
 			}
 		}
 
-		if result.NextPage == nil {
+		cursor = getNextPageToken(result.Meta)
+		if cursor == "" {
 			return "", nil
 		}
 	}
@@ -310,15 +310,17 @@ func (z *ZendeskClient) GetGroupMembershipByGroup(ctx context.Context, groupMemb
 // matches the organization ID client-side, for the same reason as
 // GetGroupMembershipByGroup: the flat endpoint ignores filter query params.
 func (z *ZendeskClient) GetOrganizationMembershipByUser(ctx context.Context, organizationMembership zendesk.OrganizationMembershipListOptions) (string, error) {
-	for page := 1; ; page++ {
+	for cursor := ""; ; {
 		var result struct {
 			OrganizationMemberships []zendesk.OrganizationMembership `json:"organization_memberships"`
-			NextPage                *string                          `json:"next_page"`
+			Meta                    zendesk.CursorPaginationMeta     `json:"meta"`
 		}
 
 		query := url.Values{}
-		query.Set("page", strconv.Itoa(page))
-		query.Set("per_page", strconv.Itoa(offsetPageSize))
+		query.Set("page[size]", strconv.Itoa(cbpPageSize))
+		if cursor != "" {
+			query.Set("page[after]", cursor)
+		}
 		path := fmt.Sprintf(pathUserOrganizationMemberships, organizationMembership.UserID)
 		body, err := z.client.Get(ctx, path+"?"+query.Encode())
 		if err != nil {
@@ -334,7 +336,8 @@ func (z *ZendeskClient) GetOrganizationMembershipByUser(ctx context.Context, org
 			}
 		}
 
-		if result.NextPage == nil {
+		cursor = getNextPageToken(result.Meta)
+		if cursor == "" {
 			return "", nil
 		}
 	}


### PR DESCRIPTION
## CXH-1734: group/org membership revoke deletes the wrong membership

### Problem
Revoking a user's group (or organization) membership could delete the user's membership in a **different** group/org.

Two compounding root causes in the revoke-time membership lookup:

1. **Flat endpoint ignores `group_id`.** The lookup queried `/group_memberships.json?user_id=X&group_id=Y`. Zendesk silently ignores `group_id` when `user_id` is also set, so it returns **all** of the user's memberships — not just the one in the target group. (Confirmed live: the flat endpoint returns every membership for the user regardless of `group_id`.)
2. **Client-side match keyed on the wrong field.** The match was `if req.UserID == membership.UserID` — i.e. it matched on `user_id` only and returned the **first** membership in the list, which is typically in another group. That membership's record ID was then passed to `DELETE /group_memberships/{id}`.

Net effect: a revoke could remove access from the wrong group/org.

### Fix
Resolve the membership ID from the **user-scoped** nested endpoint and match the correct field client-side:

- `GetGroupMembershipByGroup` → lists `/users/{id}/group_memberships.json` and matches on `membership.GroupID`.
- `GetOrganizationMembershipByUser` → lists `/users/{id}/organization_memberships.json` and matches on `membership.OrganizationID`.
- `GetGroupMemberships` (sync listing) → switched to the unambiguous nested `/groups/{id}/memberships.json` endpoint.
- Both revoke-path lookups (`GetGroupMembershipByGroup`, `GetOrganizationMembershipByUser`) use **cursor-based pagination** (`page[size]`/`page[after]`), consistent with the sync listing; the offset 10k-record cap no longer applies. (Addresses review feedback.)

The flat `/group_memberships.json` endpoint is avoided entirely because it silently drops combined filters; the `nukosuke/go-zendesk` library only exposes helpers for that flat endpoint, so the nested paths are called directly.

### Validation (live tenant)
Exercised the real `GetGroupMembershipByGroup` against a user belonging to two groups (G1, G2):

| Scenario | Fixed code | Old code |
|---|---|---|
| Revoke from **G2** | resolves G2's membership ✅ | resolves **G1's** membership ❌ (wrong group) |
| Revoke from **G1** | resolves G1's membership ✅ | — |

Re-verified end-to-end with `baton-test` after the CBP change: full sync, group grant→revoke, and org grant→revoke all resolve and remove the correct membership.

`go build`, `go vet`, and `golangci-lint run` all pass.

### Notes / follow-ups (not in this PR)
- A larger optimization — carrying `membership.ID` forward from the `Grants()` sync phase so revoke needs no lookup at all — is feasible for groups (not orgs as currently written) and needs a grant round-trip verification. Tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
