### PR TITLE
CXH-1907: Fix Zendesk team_member sync that truncated at 100

### DIFF
--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"net/url"
 	"strconv"
 	"strings"
 
@@ -14,19 +15,21 @@ import (
 	"github.com/nukosuke/go-zendesk/zendesk"
 )
 
-// cbpPageSize must be set on every CBP request — Zendesk treats requests
-// without page[size] as offset pagination on endpoints that support both,
-// which leaves meta.has_more/after_cursor empty and stops sync after page 1.
+// Without page[size], Zendesk falls back to OBP on dual-mode endpoints and
+// the response omits meta.has_more/after_cursor, stopping sync after page 1.
 const cbpPageSize = 100
 
-// Zendesk API endpoint paths for direct API calls.
 const (
+	// https://developer.zendesk.com/api-reference/ticketing/users/users/#list-users
+	pathUsers = "/users.json"
+
+	// https://developer.zendesk.com/api-reference/ticketing/users/users/#list-users-in-an-organization
+	pathOrgUsersFmt = "/organizations/%d/users.json"
+
 	// https://developer.zendesk.com/api-reference/ticketing/users/users/
-	// Permissions: Admins or agents with permission to edit end-user profiles.
 	pathUser = "/users/%d.json"
 
 	// https://developer.zendesk.com/api-reference/ticketing/users/users/#permanently-delete-user
-	// Permissions: Admins or agents with access to all tickets.
 	pathDeletedUser = "/deleted_users/%d.json"
 )
 
@@ -58,29 +61,19 @@ func New(ctx context.Context, httpClient *http.Client, subdomain string, email s
 }
 
 // ListUsers returns users with the given role using cursor-based pagination.
-// role[] array notation breaks Zendesk's cursor advancement; callers must use
-// the singular role value and manage multi-role passes themselves.
 func (z *ZendeskClient) ListUsers(ctx context.Context, role, pageToken string) ([]zendesk.User, string, error) {
-	users, meta, err := z.client.GetUsersCBP(ctx, &zendesk.CBPOptions{
-		CursorPagination: zendesk.CursorPagination{PageSize: cbpPageSize, PageAfter: pageToken},
-		CommonOptions:    zendesk.CommonOptions{Role: role},
-	})
-	if err != nil {
-		return nil, "", wrapZendeskError(err)
+	params := url.Values{}
+	if role != "" {
+		params.Set("role", role)
 	}
-	return users, getNextPageToken(meta), nil
+	return z.listUsersCBP(ctx, pathUsers, params, pageToken)
 }
 
 // ListUsersByRole returns users assigned to a specific custom role, with cursor pagination.
 func (z *ZendeskClient) ListUsersByRole(ctx context.Context, roleID int64, pageToken string) ([]zendesk.User, string, error) {
-	users, meta, err := z.client.GetUsersCBP(ctx, &zendesk.CBPOptions{
-		CursorPagination: zendesk.CursorPagination{PageSize: cbpPageSize, PageAfter: pageToken},
-		CommonOptions:    zendesk.CommonOptions{PermissionSet: roleID},
-	})
-	if err != nil {
-		return nil, "", wrapZendeskError(err)
-	}
-	return users, getNextPageToken(meta), nil
+	params := url.Values{}
+	params.Set("permission_set", strconv.FormatInt(roleID, 10))
+	return z.listUsersCBP(ctx, pathUsers, params, pageToken)
 }
 
 // ListGroups returns all ZendeskClient user groups.
@@ -156,14 +149,34 @@ func (z *ZendeskClient) GetOrganizationUsers(ctx context.Context, orgID *v2.Reso
 	if err != nil {
 		return nil, "", err
 	}
-	users, meta, err := z.client.GetOrganizationUsersCBP(ctx, &zendesk.CBPOptions{
-		CursorPagination: zendesk.CursorPagination{PageSize: cbpPageSize, PageAfter: pageToken},
-		CommonOptions:    zendesk.CommonOptions{Id: oID, Role: role},
-	})
+	params := url.Values{}
+	if role != "" {
+		params.Set("role", role)
+	}
+	return z.listUsersCBP(ctx, fmt.Sprintf(pathOrgUsersFmt, oID), params, pageToken)
+}
+
+// listUsersCBP hand-rolls the URL so go-zendesk's CommonOptions can't emit an
+// empty query= param, which disables CBP on the role-filtered users endpoints (CXH-1907).
+func (z *ZendeskClient) listUsersCBP(ctx context.Context, path string, params url.Values, pageToken string) ([]zendesk.User, string, error) {
+	params.Set("page[size]", strconv.Itoa(cbpPageSize))
+	if pageToken != "" {
+		params.Set("page[after]", pageToken)
+	}
+
+	body, err := z.client.Get(ctx, path+"?"+params.Encode())
 	if err != nil {
 		return nil, "", wrapZendeskError(err)
 	}
-	return users, getNextPageToken(meta), nil
+
+	var data struct {
+		Users []zendesk.User               `json:"users"`
+		Meta  zendesk.CursorPaginationMeta `json:"meta"`
+	}
+	if err := json.Unmarshal(body, &data); err != nil {
+		return nil, "", fmt.Errorf("baton-zendesk: decode users response: %w", err)
+	}
+	return data.Users, getNextPageToken(data.Meta), nil
 }
 
 // GetUserAccountResource creates a new connector resource for a Jamf user account.

--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -1,0 +1,193 @@
+package client
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
+	"github.com/nukosuke/go-zendesk/zendesk"
+)
+
+// CXH-1907 quirk: empty `query=` on role-filtered users endpoints disables CBP,
+// so meta.has_more / after_cursor are dropped and sync stops after one page.
+func zendeskCBPMock(t *testing.T, total int, requireParam, requireValue string) *httptest.Server {
+	t.Helper()
+	mux := http.NewServeMux()
+
+	respond := func(w http.ResponseWriter, r *http.Request) {
+		rawQuery := r.URL.RawQuery
+		values := r.URL.Query()
+
+		if requireParam != "" && values.Get(requireParam) != requireValue {
+			http.Error(w, fmt.Sprintf("missing %s=%s", requireParam, requireValue), http.StatusBadRequest)
+			return
+		}
+
+		users := make([]zendesk.User, 0, 100)
+		// Empty query= disables CBP on these endpoints. Detect the literal
+		// substring so an empty value still trips the bug.
+		cbpDisabled := containsEmptyQueryParam(rawQuery, "query")
+
+		after := values.Get("page[after]")
+		start := 0
+		if after != "" {
+			// Cursors are "p<N>" where N is the index of the first user in the next page.
+			_, err := fmt.Sscanf(after, "p%d", &start)
+			if err != nil {
+				http.Error(w, "bad cursor", http.StatusBadRequest)
+				return
+			}
+		}
+
+		end := start + 100
+		if end > total {
+			end = total
+		}
+		for i := start; i < end; i++ {
+			users = append(users, zendesk.User{ID: int64(i + 1), Name: fmt.Sprintf("user-%d", i+1)})
+		}
+
+		body := map[string]any{"users": users}
+		if !cbpDisabled && end < total {
+			body["meta"] = map[string]any{
+				"has_more":     true,
+				"after_cursor": fmt.Sprintf("p%d", end),
+			}
+		} else if !cbpDisabled {
+			body["meta"] = map[string]any{
+				"has_more":     false,
+				"after_cursor": "",
+			}
+		}
+		// When cbpDisabled is true, meta is omitted entirely (matches Zendesk's
+		// observed wire behaviour).
+
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(body)
+	}
+
+	mux.HandleFunc("/users.json", respond)
+	mux.HandleFunc("/organizations/", func(w http.ResponseWriter, r *http.Request) {
+		// /organizations/{id}/users.json
+		if !strings.HasSuffix(r.URL.Path, "/users.json") {
+			http.NotFound(w, r)
+			return
+		}
+		respond(w, r)
+	})
+
+	return httptest.NewServer(mux)
+}
+
+// containsEmptyQueryParam reports whether rawQuery serialises `key=` with an
+// empty value (the exact wire shape that disables CBP on Zendesk's role-filtered
+// users endpoints).
+func containsEmptyQueryParam(rawQuery, key string) bool {
+	for _, part := range strings.Split(rawQuery, "&") {
+		if part == key+"=" || strings.HasPrefix(part, key+"=&") {
+			return true
+		}
+	}
+	return false
+}
+
+func newTestClient(t *testing.T, baseURL string) *ZendeskClient {
+	t.Helper()
+	c, err := New(context.Background(), nil, "", "test@example.com", "token", baseURL)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	return c
+}
+
+func drainListUsers(t *testing.T, c *ZendeskClient, role string) int {
+	t.Helper()
+	ctx := context.Background()
+	total := 0
+	token := ""
+	for {
+		users, next, err := c.ListUsers(ctx, role, token)
+		if err != nil {
+			t.Fatalf("ListUsers: %v", err)
+		}
+		total += len(users)
+		if next == "" {
+			return total
+		}
+		token = next
+	}
+}
+
+func drainListUsersByRole(t *testing.T, c *ZendeskClient, roleID int64) int {
+	t.Helper()
+	ctx := context.Background()
+	total := 0
+	token := ""
+	for {
+		users, next, err := c.ListUsersByRole(ctx, roleID, token)
+		if err != nil {
+			t.Fatalf("ListUsersByRole: %v", err)
+		}
+		total += len(users)
+		if next == "" {
+			return total
+		}
+		token = next
+	}
+}
+
+func drainGetOrganizationUsers(t *testing.T, c *ZendeskClient, orgID *v2.ResourceId, role string) int {
+	t.Helper()
+	ctx := context.Background()
+	total := 0
+	token := ""
+	for {
+		users, next, err := c.GetOrganizationUsers(ctx, orgID, role, token)
+		if err != nil {
+			t.Fatalf("GetOrganizationUsers: %v", err)
+		}
+		total += len(users)
+		if next == "" {
+			return total
+		}
+		token = next
+	}
+}
+
+func TestListUsers_RoleFilteredCBPPaginatesPastFirstPage(t *testing.T) {
+	srv := zendeskCBPMock(t, 106, "role", "agent")
+	defer srv.Close()
+
+	c := newTestClient(t, srv.URL)
+	got := drainListUsers(t, c, "agent")
+	if got != 106 {
+		t.Fatalf("CXH-1907: expected 106 users across both pages, got %d (truncation regression)", got)
+	}
+}
+
+func TestListUsersByRole_PermissionSetCBPPaginatesPastFirstPage(t *testing.T) {
+	srv := zendeskCBPMock(t, 106, "permission_set", "42")
+	defer srv.Close()
+
+	c := newTestClient(t, srv.URL)
+	got := drainListUsersByRole(t, c, 42)
+	if got != 106 {
+		t.Fatalf("CXH-1907: expected 106 users across both pages, got %d (truncation regression)", got)
+	}
+}
+
+func TestGetOrganizationUsers_RoleFilteredCBPPaginatesPastFirstPage(t *testing.T) {
+	srv := zendeskCBPMock(t, 106, "role", "agent")
+	defer srv.Close()
+
+	c := newTestClient(t, srv.URL)
+	got := drainGetOrganizationUsers(t, c, &v2.ResourceId{Resource: "9001"}, "agent")
+	if got != 106 {
+		t.Fatalf("CXH-1907: expected 106 users across both pages, got %d (truncation regression)", got)
+	}
+}


### PR DESCRIPTION
Zendesk tenants with more than 100 agents now sync the full roster; the connector was inadvertently disabling Zendesk's cursor pagination on role-filtered user lookups.